### PR TITLE
ci: ensure all the images we built are signed with cosign

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -22,10 +22,13 @@ jobs:
     permissions:
       contents: read
       packages: write # Pushing images to ghcr.io
+      id-token: write # Signing images with cosign
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Login to GitHub Container Registry
@@ -53,6 +56,28 @@ jobs:
           tags: ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}
           outputs: |
             type=image,push=true,push-by-digest=true,name-canonical=true
+
+      # We need to disable the new bundle format enabled by default since
+      # cosign v3.x.x because some verification tools (e.g. slsactl, hauler and old
+      # cosign) are not able to properly verify the signatures using this
+      # new format
+      - name: Sign container image with cosign v2 signature format
+        run: |
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${{ steps.build-image.outputs.digest }}
+
+      - name: Sign container image with cosign v3 signature format
+        run: |
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${{ steps.build-image.outputs.digest }}
+
+      - name: Verify container image signature
+        run: |
+          cosign verify \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/runtime-enforcer/.github/workflows/container-build.yml@${{ github.ref }}" \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${{ steps.build-image.outputs.digest }}
+
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
@@ -70,6 +95,7 @@ jobs:
     needs: [build]
     permissions:
       packages: write # Pushing multi-arch manifest to ghcr.io
+      id-token: write # Signing images with cosign
     strategy:
       matrix:
         component: [operator, daemon]
@@ -80,7 +106,8 @@ jobs:
           path: ${{ runner.temp }}/digests
           pattern: digest-${{ matrix.component }}-*
           merge-multiple: true
-
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
       - name: Login to GHCR
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -105,13 +132,55 @@ jobs:
         id: create-manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
+          set -e
           amd64_digest=$(cat ${{ matrix.component }}-amd64.txt)
 
+          # Create the manifest locally
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}:${{ env.TAG_NAME }} \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${amd64_digest} \
+            --dry-run > expected-multi-arch-manifest.json
+
+          # Create the manifest and push it
           docker buildx imagetools create \
             -t ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}:${{ env.TAG_NAME }} \
             ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${amd64_digest} \
 
-          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}:${{ env.TAG_NAME }}
+          # The previous command is NOT printing the digest of the multi-arch manifest, we have to obtain it by
+          # fetching it from the OCI registry and **verify** its contents before signing it
+
+          # Fetch the multi arch manifest
+          docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}:${{ env.TAG_NAME }} \
+            --raw > multi-arch-manifest.json
+          multi_arch_manifest_digest="sha256:$(sha256sum multi-arch-manifest.json | awk '{print $1}')"
+
+          # Compare the contents of the manifest we previously computed and the actual one.
+          # Use jq to sort the contents and build a compact output (removing useless whitespaces),
+          # this is done to ensure the JSON documents have the same structure.
+          expected_digest="sha256:$(jq -S -c . expected-multi-arch-manifest.json | sha256sum | awk '{print $1}')"
+          actual_digest="sha256:$(jq -S -c . multi-arch-manifest.json | sha256sum | awk '{print $1}')"
+
+          if [ "$expected_digest" != "$actual_digest" ]; then
+            echo "Error: digests do not match!"
+            exit 1
+          fi
+
+          # Sign the multi-arch image manifest using cosign v2 format
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${multi_arch_manifest_digest}
+
+          # Sign the multi-arch image manifest using cosign v3 format
+          cosign sign --yes --new-bundle-format=true --use-signing-config=true \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${multi_arch_manifest_digest}
+
+          echo "MULTI_ARCH_MANIFEST_DIGEST=$multi_arch_manifest_digest" >> $GITHUB_ENV
+
+      - name: Verify multi-arch manifest signature
+        run: |
+          cosign verify \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+            --certificate-identity="https://github.com/${{github.repository_owner}}/runtime-enforcer/.github/workflows/container-build.yml@${{ github.ref }}" \
+            ghcr.io/${{ github.repository_owner }}/runtime-enforcer/${{ matrix.component }}@${{ env.MULTI_ARCH_MANIFEST_DIGEST}} 
 
   attest:
     needs: [merge]


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR fixes the issue where image manifest is not signed based on https://github.com/kubewarden/sbomscanner/pull/573

Before the change:
```
$ cosign verify   --certificate-identity-regexp="https://github.com/neuvector/runtime-enforcer/.*"   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"   --offline=true   --use-signed-timestamps=true ghcr.io/neuvector/runtime-enforcer/daemon:latest
Error: no signatures found
error during command execution: no signatures found
```

After the change (on my own fork):

```
$ cosign verify   --certificate-identity-regexp="https://github.com/holyspectral/runtime-enforcer/.*"   --certificate-oidc-issuer="https://token.actions.githubusercontent.com"   --offline=true   --use-signed-timestamps=true  ghcr.io/holyspectral/runtime-enforcer/daemon:latest

Verification for ghcr.io/holyspectral/runtime-enforcer/daemon:latest --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

**Which issue(s) this PR fixes**
Issue #8

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
