### PR TITLE
chore: pin helm version to 3.19.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.19.0
       - name: Install Helm-unittest
         run: helm plugin install https://github.com/helm-unittest/helm-unittest
       - run: make helm-unittest


### PR DESCRIPTION
Just trying to pin helm to 3.19.0 during the CI to see if we get rid of plugin installation errors