### PR TITLE
feat: add finalizer management for WorkloadSecurityPolicy

### DIFF
--- a/charts/runtime-enforcer/templates/operator/role.yaml
+++ b/charts/runtime-enforcer/templates/operator/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: {{ include "runtime-enforcer.fullname" . }}-operator
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/charts/runtime-enforcer/templates/operator/webhook.yaml
+++ b/charts/runtime-enforcer/templates/operator/webhook.yaml
@@ -33,3 +33,26 @@ webhooks:
     expression: '!has(object.spec.selector) || object.spec.selector.size() == 0'
   - name: no-owner-reference-uid
     expression: '!has(object.metadata.ownerReferences) || object.metadata.ownerReferences.size() == 0 || object.metadata.ownerReferences[0].uid.size() == 0'
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "runtime-enforcer.fullname" . }}-mutating-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-security-rancher-io-v1alpha1-workloadsecuritypolicy
+  failurePolicy: Fail
+  name: workloadsecuritypolicies.rancher.io
+  rules:
+  - apiGroups:
+    - security.rancher.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloadsecuritypolicies
+  sideEffects: None
+  matchConditions:
+  - name: finalizer-not-present
+    expression: '!has(object.metadata.finalizers) || !("workloadsecuritypolicy.security.rancher.io/finalizer" in object.metadata.finalizers)'

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -256,7 +256,16 @@ func main() {
 		WithDefaulter(&controller.ProposalWebhook{Client: mgr.GetClient()}).
 		Complete()
 	if err != nil {
-		setupLog.Error(err, "unable to create a webhook")
+		setupLog.Error(err, "unable to create WorkloadSecurityPolicyProposal webhook")
+		os.Exit(1)
+	}
+
+	err = builder.WebhookManagedBy(mgr).
+		For(&securityv1alpha1.WorkloadSecurityPolicy{}).
+		WithDefaulter(&controller.PolicyWebhook{}).
+		Complete()
+	if err != nil {
+		setupLog.Error(err, "unable to create WorkloadSecurityPolicy webhook")
 		os.Exit(1)
 	}
 

--- a/internal/controller/workloadsecuritypolicy_controller.go
+++ b/internal/controller/workloadsecuritypolicy_controller.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	tetragonv1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	securityv1alpha1 "github.com/neuvector/runtime-enforcer/api/v1alpha1"
@@ -26,6 +32,7 @@ type WorkloadSecurityPolicyReconciler struct {
 // +kubebuilder:rbac:groups=security.rancher.io,resources=workloadsecuritypolicies/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=security.rancher.io,resources=workloadsecuritypolicies/finalizers,verbs=update
 // +kubebuilder:rbac:groups=cilium.io,resources=tracingpoliciesnamespaced,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 
 func (r *WorkloadSecurityPolicyReconciler) Reconcile(
 	ctx context.Context,
@@ -42,7 +49,7 @@ func (r *WorkloadSecurityPolicyReconciler) Reconcile(
 	}
 
 	if policy.GetDeletionTimestamp() != nil {
-		return ctrl.Result{}, nil
+		return r.handleDeletion(ctx, &policy)
 	}
 
 	tetragonPolicy := tetragonv1alpha1.TracingPolicyNamespaced{
@@ -67,6 +74,80 @@ func (r *WorkloadSecurityPolicyReconciler) Reconcile(
 	return ctrl.Result{}, r.updateStatus(ctx, &policy)
 }
 
+func (r *WorkloadSecurityPolicyReconciler) handleDeletion(
+	ctx context.Context,
+	policy *securityv1alpha1.WorkloadSecurityPolicy,
+) (ctrl.Result, error) {
+	log := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(policy, WorkloadSecurityPolicyFinalizer) {
+		return ctrl.Result{}, nil
+	}
+
+	hasPods, err := r.hasPodsUsingPolicy(ctx, policy)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if hasPods {
+		log.Info("policy is still in use by pods, cannot delete", "policy", policy.Name)
+		return ctrl.Result{}, nil
+	}
+
+	tetragonPolicy := tetragonv1alpha1.TracingPolicyNamespaced{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policy.Name,
+			Namespace: policy.Namespace,
+		},
+	}
+	if deleteErr := r.Delete(ctx, &tetragonPolicy); deleteErr != nil && !errors.IsNotFound(deleteErr) {
+		return ctrl.Result{}, fmt.Errorf("failed to delete tetragon policy: %w", deleteErr)
+	}
+
+	controllerutil.RemoveFinalizer(policy, WorkloadSecurityPolicyFinalizer)
+	if updateErr := r.Update(ctx, policy); updateErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to remove finalizer: %w", updateErr)
+	}
+
+	log.Info("successfully removed finalizer and cleaned up resources")
+	return ctrl.Result{}, nil
+}
+
+func (r *WorkloadSecurityPolicyReconciler) hasPodsUsingPolicy(
+	ctx context.Context,
+	policy *securityv1alpha1.WorkloadSecurityPolicy,
+) (bool, error) {
+	// If no selector is specified, we can't determine which pods use the policy
+	// In this case, we'll assume no pods are using it
+	if policy.Spec.Selector == nil {
+		return false, nil
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(policy.Spec.Selector)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert label selector: %w", err)
+	}
+
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(policy.Namespace),
+	}
+
+	if listErr := r.List(ctx, podList, listOpts...); listErr != nil {
+		return false, fmt.Errorf("failed to list pods: %w", listErr)
+	}
+
+	for _, pod := range podList.Items {
+		if pod.GetDeletionTimestamp() != nil {
+			continue
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (r *WorkloadSecurityPolicyReconciler) updateStatus(
 	ctx context.Context,
 	policy *securityv1alpha1.WorkloadSecurityPolicy,
@@ -77,6 +158,71 @@ func (r *WorkloadSecurityPolicyReconciler) updateStatus(
 	return r.Status().Update(ctx, newPolicy)
 }
 
+// mapPodsToPolicies maps pod events to WorkloadSecurityPolicy reconciles.
+// When a pod is deleted, it triggers reconciles for all policies in the same namespace
+// that might match that pod, allowing policies waiting for deletion to proceed.
+func (r *WorkloadSecurityPolicyReconciler) mapPodsToPolicies(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	logger := log.FromContext(ctx)
+
+	policyList := &securityv1alpha1.WorkloadSecurityPolicyList{}
+	if err := r.List(ctx, policyList, client.InNamespace(pod.Namespace)); err != nil {
+		logger.Error(
+			err,
+			"failed to list WorkloadSecurityPolicies when mapping pod to policies",
+			"pod",
+			pod.Name,
+			"namespace",
+			pod.Namespace,
+		)
+		return []reconcile.Request{}
+	}
+
+	var requests []reconcile.Request
+	for _, policy := range policyList.Items {
+		if policy.GetDeletionTimestamp() == nil {
+			continue
+		}
+
+		if policy.Spec.Selector == nil {
+			continue
+		}
+
+		selector, err := metav1.LabelSelectorAsSelector(policy.Spec.Selector)
+		if err != nil {
+			logger.Error(err, "failed to convert label selector when mapping pod to policies", "policy", policy.Name)
+			continue
+		}
+
+		if selector.Matches(labels.Set(pod.Labels)) {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      policy.Name,
+					Namespace: policy.Namespace,
+				},
+			})
+			logger.Info(
+				"pod deletion triggered policy reconcile",
+				"pod",
+				pod.Name,
+				"policy",
+				policy.Name,
+				"namespace",
+				pod.Namespace,
+			)
+		}
+	}
+
+	return requests
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkloadSecurityPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := tetragonv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
@@ -84,6 +230,10 @@ func (r *WorkloadSecurityPolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&securityv1alpha1.WorkloadSecurityPolicy{}).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.mapPodsToPolicies),
+		).
 		Named("workloadsecuritypolicy").
 		Complete(r)
 }

--- a/internal/controller/workloadsecuritypolicy_controller_test.go
+++ b/internal/controller/workloadsecuritypolicy_controller_test.go
@@ -6,7 +6,10 @@ import (
 	tragonv1alpha1 "github.com/cilium/tetragon/pkg/k8s/apis/cilium.io/v1alpha1"
 	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
 	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -207,6 +210,360 @@ var _ = Describe("WorkloadSecurityPolicy Controller", func() {
 				Expect(tetragonPolicySpec.KProbes[0]).To(Equal(tc.Expected))
 			}
 
+		})
+	})
+
+	Context("When deleting a resource", func() {
+		It("should not delete if pods are using the policy", func() {
+			const resourceName = "test-deletion-with-pods"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			By("creating a policy with selector and finalizer")
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{controller.WorkloadSecurityPolicyFinalizer},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test-deletion",
+						},
+					},
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+					Severity: 10,
+					Tags:     []string{},
+					Message:  "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("creating a pod matching the selector")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-deletion",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test-deletion",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "nginx:latest",
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			By("deleting the policy (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling should not remove finalizer")
+			controllerReconciler := &controller.WorkloadSecurityPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying finalizer is still present")
+			updatedPolicy := &securityv1alpha1.WorkloadSecurityPolicy{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, updatedPolicy)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(
+				updatedPolicy,
+				controller.WorkloadSecurityPolicyFinalizer,
+			)).To(BeTrue())
+
+			By("cleaning up pod")
+			Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+
+			By("waiting for pod to be deleted")
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)
+				return errors.IsNotFound(getErr)
+			}).Should(BeTrue())
+
+			By("reconciling again to remove finalizer now that pod is gone")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying policy is deleted")
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, typeNamespacedName, updatedPolicy)
+				return errors.IsNotFound(getErr)
+			}).Should(BeTrue())
+		})
+
+		It("should delete Tetragon policy and remove finalizer when no pods exist", func() {
+			const resourceName = "test-deletion-no-pods"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			By("creating a policy with selector and finalizer")
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{controller.WorkloadSecurityPolicyFinalizer},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test-deletion-no-pods",
+						},
+					},
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+					Severity: 10,
+					Tags:     []string{},
+					Message:  "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("creating Tetragon policy")
+			tetragonPolicy := &tragonv1alpha1.TracingPolicyNamespaced{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: tragonv1alpha1.TracingPolicySpec{
+					KProbes: []tragonv1alpha1.KProbeSpec{
+						{
+							Call:    "security_bprm_creds_for_exec",
+							Syscall: false,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, tetragonPolicy)).To(Succeed())
+
+			By("deleting the policy (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling should remove finalizer and delete Tetragon policy")
+			controllerReconciler := &controller.WorkloadSecurityPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying Tetragon policy is deleted")
+			deletedTetragonPolicy := &tragonv1alpha1.TracingPolicyNamespaced{}
+			getErr := k8sClient.Get(ctx, typeNamespacedName, deletedTetragonPolicy)
+			Expect(errors.IsNotFound(getErr)).To(BeTrue())
+
+			By("verifying finalizer is removed and policy is deleted")
+			updatedPolicy := &securityv1alpha1.WorkloadSecurityPolicy{}
+			Eventually(func() bool {
+				checkErr := k8sClient.Get(ctx, typeNamespacedName, updatedPolicy)
+				return errors.IsNotFound(checkErr)
+			}).Should(BeTrue())
+		})
+
+		It("should ignore pods with deletion timestamp", func() {
+			const resourceName = "test-deletion-pods-deleting"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			By("creating a policy with selector and finalizer")
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{controller.WorkloadSecurityPolicyFinalizer},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test-deletion-pods-deleting",
+						},
+					},
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+					Severity: 10,
+					Tags:     []string{},
+					Message:  "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("creating a pod matching the selector")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod-deleting",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "test-deletion-pods-deleting",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "nginx:latest",
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			By("deleting the pod (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+
+			By("deleting the policy (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling should proceed with deletion since pod is being deleted")
+			controllerReconciler := &controller.WorkloadSecurityPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying finalizer is removed and policy is deleted")
+			updatedPolicy := &securityv1alpha1.WorkloadSecurityPolicy{}
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, typeNamespacedName, updatedPolicy)
+				return errors.IsNotFound(getErr)
+			}).Should(BeTrue())
+		})
+
+		It("should allow deletion when policy has no selector", func() {
+			const resourceName = "test-deletion-no-selector"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			By("creating a policy without selector and with finalizer")
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Namespace:  "default",
+					Finalizers: []string{controller.WorkloadSecurityPolicyFinalizer},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+					Severity: 10,
+					Tags:     []string{},
+					Message:  "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("deleting the policy (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling should proceed with deletion")
+			controllerReconciler := &controller.WorkloadSecurityPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying finalizer is removed and policy is deleted")
+			updatedPolicy := &securityv1alpha1.WorkloadSecurityPolicy{}
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, typeNamespacedName, updatedPolicy)
+				return errors.IsNotFound(getErr)
+			}).Should(BeTrue())
+		})
+
+		It("should handle deletion when finalizer is already removed", func() {
+			const resourceName = "test-deletion-no-finalizer"
+			typeNamespacedName := types.NamespacedName{
+				Name:      resourceName,
+				Namespace: "default",
+			}
+
+			By("creating a policy without finalizer")
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: "default",
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+					Severity: 10,
+					Tags:     []string{},
+					Message:  "",
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			By("deleting the policy (which sets deletion timestamp)")
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			By("reconciling should handle gracefully")
+			controllerReconciler := &controller.WorkloadSecurityPolicyReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying policy is deleted")
+			Eventually(func() bool {
+				getErr := k8sClient.Get(ctx, typeNamespacedName, policy)
+				return errors.IsNotFound(getErr)
+			}).Should(BeTrue())
 		})
 	})
 })

--- a/internal/controller/workloadsecuritypolicy_webhook.go
+++ b/internal/controller/workloadsecuritypolicy_webhook.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	securityv1alpha1 "github.com/neuvector/runtime-enforcer/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	WorkloadSecurityPolicyFinalizer = "workloadsecuritypolicy.security.rancher.io/finalizer"
+)
+
+type PolicyWebhook struct{}
+
+// Default adds a finalizer to WorkloadSecurityPolicy on CREATE events.
+func (w *PolicyWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	logger := log.FromContext(ctx)
+
+	policy, ok := obj.(*securityv1alpha1.WorkloadSecurityPolicy)
+	if !ok {
+		return fmt.Errorf("expected a WorkloadSecurityPolicy but got a %T", obj)
+	}
+
+	if !controllerutil.ContainsFinalizer(policy, WorkloadSecurityPolicyFinalizer) {
+		controllerutil.AddFinalizer(policy, WorkloadSecurityPolicyFinalizer)
+		logger.Info("added finalizer to WorkloadSecurityPolicy", "finalizer", WorkloadSecurityPolicyFinalizer)
+	}
+
+	return nil
+}

--- a/internal/controller/workloadsecuritypolicy_webhook_test.go
+++ b/internal/controller/workloadsecuritypolicy_webhook_test.go
@@ -1,0 +1,118 @@
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:revive // Required for testing
+	. "github.com/onsi/gomega"    //nolint:revive // Required for testing
+
+	securityv1alpha1 "github.com/neuvector/runtime-enforcer/api/v1alpha1"
+	"github.com/neuvector/runtime-enforcer/internal/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("WorkloadSecurityPolicy Webhook", func() {
+	Context("When creating a WorkloadSecurityPolicy", func() {
+		It("should add finalizer on CREATE", func() {
+			By("creating a policy without finalizer")
+
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-policy",
+					Namespace: "default",
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app": "test",
+						},
+					},
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{
+								"/usr/bin/sleep",
+							},
+						},
+					},
+				},
+			}
+
+			webhook := &controller.PolicyWebhook{}
+			err := webhook.Default(ctx, policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controllerutil.ContainsFinalizer(policy, controller.WorkloadSecurityPolicyFinalizer)).To(BeTrue())
+			Expect(policy.Finalizers).To(ContainElement(controller.WorkloadSecurityPolicyFinalizer))
+		})
+
+		It("should be idempotent - not add duplicate finalizer", func() {
+			By("creating a policy with finalizer already present")
+
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-policy-idempotent",
+					Namespace:  "default",
+					Finalizers: []string{controller.WorkloadSecurityPolicyFinalizer},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.MonitorMode,
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							Allowed: []string{"/usr/bin/sleep"},
+						},
+					},
+				},
+			}
+
+			initialFinalizerCount := len(policy.Finalizers)
+
+			webhook := &controller.PolicyWebhook{}
+			err := webhook.Default(ctx, policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy.Finalizers).To(HaveLen(initialFinalizerCount))
+			Expect(policy.Finalizers).To(ContainElement(controller.WorkloadSecurityPolicyFinalizer))
+		})
+
+		It("should add finalizer even when other finalizers exist", func() {
+			By("creating a policy with other finalizers")
+
+			policy := &securityv1alpha1.WorkloadSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-policy-multiple-finalizers",
+					Namespace:  "default",
+					Finalizers: []string{"other-finalizer"},
+				},
+				Spec: securityv1alpha1.WorkloadSecurityPolicySpec{
+					Mode: securityv1alpha1.ProtectMode,
+					Rules: securityv1alpha1.WorkloadSecurityPolicyRules{
+						Executables: securityv1alpha1.WorkloadSecurityPolicyExecutables{
+							AllowedPrefixes: []string{"/bin/"},
+						},
+					},
+				},
+			}
+
+			webhook := &controller.PolicyWebhook{}
+			err := webhook.Default(ctx, policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policy.Finalizers).To(ContainElement("other-finalizer"))
+			Expect(policy.Finalizers).To(ContainElement(controller.WorkloadSecurityPolicyFinalizer))
+			Expect(policy.Finalizers).To(HaveLen(2))
+		})
+
+		It("should return error for wrong object type", func() {
+			By("passing wrong object type to webhook")
+
+			wrongObject := &securityv1alpha1.WorkloadSecurityPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wrong-type",
+					Namespace: "default",
+				},
+			}
+
+			webhook := &controller.PolicyWebhook{}
+			err := webhook.Default(ctx, wrongObject)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a WorkloadSecurityPolicy"))
+		})
+	})
+})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
- Mutating webhook adds finalizer on CREATE events for WorkloadSecurityPolicy
- Reconciler blocks deletion when pods are using the Policy
- Pod watch triggers reconciliation on pod deletion
- Finalizer removed only if there are no pods making use of that Policy

**Which issue(s) this PR fixes**
Issue #56 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
