### PR TITLE
fix: disable ebpf logs by default

### DIFF
--- a/bpf/debug.h
+++ b/bpf/debug.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#undef bpf_printk
+#define bpf_printk(fmt, ...)                                                    \
+	({                                                                          \
+		if(load_time_config.debug_mode == 1) {                                  \
+			static char ____fmt[] = fmt "\0";                                   \
+			if(bpf_core_type_exists(struct trace_event_raw_bpf_trace_printk)) { \
+				bpf_trace_printk(____fmt, sizeof(____fmt) - 1, ##__VA_ARGS__);  \
+			} else {                                                            \
+				____fmt[sizeof(____fmt) - 2] = '\n';                            \
+				bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__);      \
+			}                                                                   \
+		}                                                                       \
+	})

--- a/bpf/main.c
+++ b/bpf/main.c
@@ -5,6 +5,7 @@
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_tracing.h>
 #include "load_conf.h"
+#include "debug.h"
 #include "helpers.h"
 #include "string_maps.h"
 #include "d_path_resolution.h"


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, we don't want to print EBPF logs to the console. In the future, we might enable them in production, but for now, they are meant to be used only during development

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
