### PR TITLE
support arm64 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,5 @@ tilt-settings.yaml
 .husky
 
 # bpf objects
-internal/bpf/bpf_bpfeb.o
-internal/bpf/bpf_bpfel.o
-internal/bpf/bpf_bpfeb.go
-internal/bpf/bpf_bpfel.go
+internal/bpf/bpf_*bpfeb.o
+internal/bpf/bpf_*bpfel.o

--- a/internal/bpf/manager.go
+++ b/internal/bpf/manager.go
@@ -16,9 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// todo!: we need to generate according to the architecture, not just x86
-
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g -D__TARGET_ARCH_x86" -tags linux -target bpfel -type process_evt bpf ../../bpf/main.c -- -I/usr/include/
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cflags "-O2 -g" -target native -tags linux -type process_evt bpf ../../bpf/main.c -- -I/usr/include/
 
 const (
 	loadTimeConfigBPFVar = "load_time_config"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR enables arm64 build in runtime enforcer project. 
 
1. use "native" option to build ebpf program and related go code.  This
   way docker multi-arch can work in emulated arm64 environment.
2. arm64 build can be enabled via emulation from now on via below
   command.

After this change, you can build arm64 images using this command:

```
docker buildx build -f package/Dockerfile.daemon --builder <buildx builder> -t <image> --load --platform=linux/arm64 .
```

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
