### PR TITLE
fix: add generate-ebpf to operator make goal too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ lint-config: golangci-lint ## Verify golangci-lint linter configuration
 ##@ Build
 
 .PHONY: operator
-operator: fmt ## Build manager binary.
+operator: generate-ebpf fmt ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux go build -o bin/operator ./cmd/operator
 
 .PHONY: test-bpf

--- a/package/Dockerfile.operator
+++ b/package/Dockerfile.operator
@@ -1,8 +1,13 @@
 FROM docker.io/library/golang:1.25.5 AS builder
+
+RUN apt update
+RUN apt install -y build-essential libelf-dev clang llvm libbpf-dev
+
 WORKDIR /src
 COPY api/ /src/api
 COPY cmd/ /src/cmd
 COPY pkg/ /src/pkg
+COPY bpf/ /src/bpf/
 COPY internal/ /src/internal
 COPY go.mod go.sum /src/
 COPY Makefile /src/


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:
Since we now bundle our bpf code, when compiling the operator is very likely (due to tree shaking not being done anymore on those specific modules) that we have to generate the eBPF code before building.

**Which issue(s) this PR fixes**
No issue (in the Issues section LOL)