### PR TITLE
refactor: improve cri-client logging

### DIFF
--- a/internal/resolver/cri_client.go
+++ b/internal/resolver/cri_client.go
@@ -64,9 +64,10 @@ func newCRIResolver(ctx context.Context, logger *slog.Logger) (*criResolver, err
 		criClient.endpoint = ep
 		criClient.client, err = newClientTry(criClient.endpoint)
 		if err == nil {
+			criClient.logger.InfoContext(ctx, "created CRI client", "endpoint", criClient.endpoint)
 			return criClient, nil
 		}
-		criClient.logger.ErrorContext(ctx, "cannot create CRI client", "endpoint", criClient.endpoint, "error", err)
+		criClient.logger.InfoContext(ctx, "cannot create CRI client", "endpoint", criClient.endpoint, "error", err)
 	}
 	return nil, err
 }
@@ -203,6 +204,7 @@ func (c *criResolver) getCgroupPath(containerID string) (string, error) {
 	var path, containerJSON string
 	if infoJSON, ok := info["info"]; ok {
 		containerJSON = infoJSON
+		// this path doesn't work for cri-dockerd. Minikube by default runs with cri-dockerd.
 		path = "runtimeSpec.linux.cgroupsPath"
 	} else {
 		return "", errors.New("could not find info")


### PR DESCRIPTION
**What this PR does / why we need it**:

We evaluate sockets in order

```go
for _, ep := range []string{
		"unix:///run/containerd/containerd.sock",
		"unix:///run/crio/crio.sock",
		"unix:///var/run/cri-dockerd.sock",
} 
```
So it's ok if some of them will fail, we shouldn't log an error, but just an info. Moreover, we should tell which socket is used at the end 


**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
