### PR TITLE
fix: the noise when standalone pod is present

### DIFF
--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -91,6 +91,19 @@ func (r *LearningReconciler) Reconcile(
 	var err error
 	var proposalName string
 
+	if req.WorkloadKind == "Pod" {
+		// We don't support learning on standalone pods
+
+		log.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+			"Ignoring learning event",
+			"workload", req.Workload,
+			"workload_kind", req.WorkloadKind,
+			"exe", req.ExecutablePath,
+		)
+
+		return ctrl.Result{}, nil
+	}
+
 	proposalName, err = GetWorkloadPolicyProposalName(req.WorkloadKind, req.Workload)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get proposal name: %w", err)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

When a standalone pod not associated to any high-level workload is present, daemon will try to learn the behavior and fail with the error below:

```
{"level":"error","ts":"2026-01-14T21:43:14Z","msg":"Reconciler error","controller":"learningEvent","reconcileID":"16575957-ad6f-49d1-b9c6-0e140046237d","error":"failed to get proposal name: unknown kind: Pod","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296"}
```

This PR fixes the issue by ignoring events from `Pod` in controller.  

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
