### PR TITLE
chore: run with `privileged:true` by default

### DIFF
--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -33,13 +33,17 @@ daemon:
     args:
     - ""
     containerSecurityContext:
+      privileged: true
+      allowPrivilegeEscalation: true
+      # In some environments it is possible to run without full privileges.
+      # To do that put `privileged: false` and `allowPrivilegeEscalation: false`.
+      #
       # Minimal capabilities required for eBPF operations:
       # - CAP_BPF: Required for loading eBPF programs
       # - CAP_PERFMON: Required for attaching tracing programs (kprobes/tracepoints)
       # - CAP_SYS_RESOURCE: Required for removing memlock limits (rlimit.RemoveMemlock)
       # - CAP_SYS_PTRACE: Required to access host cgroup filesystem
-      # - CAP_SYS_ADMIN: Required for accessing BTF in older kernels
-      allowPrivilegeEscalation: false
+      # - CAP_SYS_ADMIN: mitigation required for accessing BTF in older kernels (see: https://github.com/neuvector/runtime-enforcer/issues/152)
       capabilities:
         add:
           - BPF


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

As we discussed, async, probably for the first version, is better to run with full privileges; users are still free to disable it with 
```bash
--set daemon.daemon.containerSecurityContext.privileged=false \
--set daemon.daemon.containerSecurityContext.allowPrivilegeEscalation=false \
```

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
