### PR TITLE
refactor: rename daemon to agent

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        component: [operator, daemon]
+        component: [operator, agent]
         arch: [amd64]
         include:
           - arch: amd64
@@ -44,7 +44,7 @@ jobs:
       id-token: write # Signing images with cosign
     strategy:
       matrix:
-        component: [operator, daemon]
+        component: [operator, agent]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        component: [operator, daemon]
+        component: [operator, agent]
         arch: [amd64]
         include:
           - arch: amd64
@@ -40,7 +40,7 @@ jobs:
       id-token: write # Signing images with cosign
     strategy:
       matrix:
-        component: [operator, daemon]
+        component: [operator, agent]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,7 +56,7 @@ jobs:
     name: Sign attestations and upload as artifacts
     strategy:
       matrix:
-        component: [operator, daemon]
+        component: [operator, agent]
         arch: [amd64]
         include:
           - arch: amd64
@@ -121,10 +121,10 @@ jobs:
             let fs = require('fs');
             let path = require('path');
             let files = [
-                'RuntimeEnforcer-daemon-attestation-amd64-provenance.intoto.jsonl',
-                'RuntimeEnforcer-daemon-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
-                'RuntimeEnforcer-daemon-attestation-amd64-sbom.json',
-                'RuntimeEnforcer-daemon-attestation-amd64-sbom.json.bundle.sigstore',
+                'RuntimeEnforcer-agent-attestation-amd64-provenance.intoto.jsonl',
+                'RuntimeEnforcer-agent-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
+                'RuntimeEnforcer-agent-attestation-amd64-sbom.json',
+                'RuntimeEnforcer-agent-attestation-amd64-sbom.json.bundle.sigstore',
                 'RuntimeEnforcer-operator-attestation-amd64-provenance.intoto.jsonl',
                 'RuntimeEnforcer-operator-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
                 'RuntimeEnforcer-operator-attestation-amd64-sbom.json',

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=operator-role crd webhook paths="./api/v1alpha1" paths="./internal/controller" output:crd:artifacts:config=charts/runtime-enforcer/templates/crd output:rbac:artifacts:config=charts/runtime-enforcer/templates/operator
-	$(CONTROLLER_GEN) rbac:roleName=daemon-role paths="./cmd/daemon" paths="./internal/eventhandler" output:rbac:artifacts:config=charts/runtime-enforcer/templates/daemon
+	$(CONTROLLER_GEN) rbac:roleName=agent-role paths="./cmd/agent" paths="./internal/eventhandler" output:rbac:artifacts:config=charts/runtime-enforcer/templates/agent
 	sed -i 's/operator-role/{{ include "runtime-enforcer.fullname" . }}-operator/' charts/runtime-enforcer/templates/operator/role.yaml
-	sed -i 's/daemon-role/{{ include "runtime-enforcer.fullname" . }}-daemon/' charts/runtime-enforcer/templates/daemon/role.yaml
+	sed -i 's/agent-role/{{ include "runtime-enforcer.fullname" . }}-agent/' charts/runtime-enforcer/templates/agent/role.yaml
 
 REPO ?= ghcr.io/neuvector/runtime-enforcer
 TAG ?= latest
@@ -61,7 +61,7 @@ build-$(1)-image:
 E2E_DEPS += build-$(1)-image
 endef
 
-TARGET=operator daemon
+TARGET=operator agent
 $(foreach T,$(TARGET),$(eval $(call BUILD_template,$(T))))
 
 .PHONY: generate
@@ -121,9 +121,9 @@ operator: generate-ebpf fmt ## Build manager binary.
 test-bpf: generate-ebpf ## Run bpf tests.
 	go test -v ./internal/bpf -count=1 -exec "sudo -E"
 
-.PHONY: daemon
-daemon: generate-ebpf fmt ## Build daemon binary.
-	CGO_ENABLED=0 GOOS=linux go build -o bin/daemon ./cmd/daemon
+.PHONY: agent
+agent: generate-ebpf fmt ## Build agent binary.
+	CGO_ENABLED=0 GOOS=linux go build -o bin/agent ./cmd/agent
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/charts/runtime-enforcer/questions.yaml
+++ b/charts/runtime-enforcer/questions.yaml
@@ -25,20 +25,20 @@ questions:
       Number of replicas of the Operator Deployment
     group: Operator
 
+###############################################################################
+  # Agent
   ###############################################################################
-  # Daemon
-  ###############################################################################
-  - variable: daemon.daemon.image.pullPolicy
+  - variable: agent.agent.image.pullPolicy
     type: enum
     options:
       - Always
       - IfNotPresent
       - Never
     default: IfNotPresent
-    label: Daemon Image Pull Policy
+    label: Agent Image Pull Policy
     description: |
-      Pull policy of the Daemon DaemonSet
-    group: Daemon
+      Pull policy of Agent DaemonSet
+    group: Agent
 
   ###############################################################################
   # Learning

--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "runtime-enforcer.fullname" . }}-daemon
+  name: {{ include "runtime-enforcer.fullname" . }}-agent
   labels:
   {{- include "runtime-enforcer.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: daemon
+      app.kubernetes.io/component: agent
     {{- include "runtime-enforcer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: daemon
+        app.kubernetes.io/component: agent
       {{- include "runtime-enforcer.selectorLabels" . | nindent 8 }}
       annotations:
-        kubectl.kubernetes.io/default-container: daemon
+        kubectl.kubernetes.io/default-container: agent
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -29,16 +29,16 @@ spec:
         {{- if .Values.learning.enabled }}
         - --enable-learning
         {{- end }}
-        {{- toYaml .Values.daemon.daemon.args | nindent 8 }}
+        {{- toYaml .Values.agent.agent.args | nindent 8 }}
         command:
-        - /daemon
+        - /agent
         env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
           - name: CUSTOM_CRI_SOCKET_PATH
-            value: {{ .Values.daemon.customCRISocketPath }}
+            value: {{ .Values.agent.customCRISocketPath }}
         {{- if or .Values.telemetry.metrics .Values.telemetry.tracing }}
         {{- if eq .Values.telemetry.mode "custom" }}
           - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -57,12 +57,12 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        image: {{ .Values.daemon.daemon.image.repository }}:{{ .Values.daemon.daemon.image.tag
+        image: {{ .Values.agent.agent.image.repository }}:{{ .Values.agent.agent.image.tag
           | default .Chart.AppVersion }}
-        imagePullPolicy: {{ .Values.daemon.daemon.image.pullPolicy }}
-        name: daemon
-        resources: {{- toYaml .Values.daemon.daemon.resources | nindent 10 }}
-        securityContext: {{- toYaml .Values.daemon.daemon.containerSecurityContext | nindent 10 }}
+        imagePullPolicy: {{ .Values.agent.agent.image.pullPolicy }}
+        name: agent
+        resources: {{- toYaml .Values.agent.agent.resources | nindent 10 }}
+        securityContext: {{- toYaml .Values.agent.agent.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - name: crio-socket
           mountPath: /run/crio/crio.sock
@@ -77,14 +77,14 @@ spec:
           mountPath: /var/run/nri/nri.sock
           mountPropagation: HostToContainer
           readOnly: true
-        {{- if .Values.daemon.customCRISocketPath }}
+        {{- if .Values.agent.customCRISocketPath }}
         - name: custom-cri-socket
-          mountPath: {{ .Values.daemon.customCRISocketPath }}
+          mountPath: {{ .Values.agent.customCRISocketPath }}
           readOnly: true
         {{- end }}
-      hostPID: {{ .Values.daemon.hostPID }}
-      securityContext: {{- toYaml .Values.daemon.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ include "runtime-enforcer.fullname" . }}-daemon
+      hostPID: {{ .Values.agent.hostPID }}
+      securityContext: {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "runtime-enforcer.fullname" . }}-agent
       terminationGracePeriodSeconds: 10
       volumes:
       # We try to mount common CRI socket paths. If these are not enough, users should mount the correct socket using criSocketPath value.
@@ -97,11 +97,11 @@ spec:
       - name: dockerd-socket
         hostPath:
           path: /run/cri-dockerd.sock
-      {{- if .Values.daemon.customCRISocketPath }}
+      {{- if .Values.agent.customCRISocketPath }}
       - name: custom-cri-socket
         hostPath:
-          path: {{ .Values.daemon.customCRISocketPath }}
+          path: {{ .Values.agent.customCRISocketPath }}
       {{- end }}
       - name: nri-socket
         hostPath:
-          path: {{ .Values.daemon.nriSocketPath }}
+          path: {{ .Values.agent.nriSocketPath }}

--- a/charts/runtime-enforcer/templates/agent/role.yaml
+++ b/charts/runtime-enforcer/templates/agent/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "runtime-enforcer.fullname" . }}-daemon
+  name: {{ include "runtime-enforcer.fullname" . }}-agent
 rules:
 - apiGroups:
   - ""

--- a/charts/runtime-enforcer/templates/agent/rolebinding.yaml
+++ b/charts/runtime-enforcer/templates/agent/rolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "runtime-enforcer.fullname" . }}-daemon-rolebinding
+  name: {{ include "runtime-enforcer.fullname" . }}-agent-rolebinding
   labels:
   {{- include "runtime-enforcer.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "runtime-enforcer.fullname" . }}-daemon'
+  name: '{{ include "runtime-enforcer.fullname" . }}-agent'
 subjects:
 - kind: ServiceAccount
-  name: '{{ include "runtime-enforcer.fullname" . }}-daemon'
+  name: '{{ include "runtime-enforcer.fullname" . }}-agent'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/runtime-enforcer/templates/agent/serviceaccount.yaml
+++ b/charts/runtime-enforcer/templates/agent/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "runtime-enforcer.fullname" . }}-agent
+  labels:
+  {{- include "runtime-enforcer.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.agent.serviceAccount.annotations | nindent 4 }}

--- a/charts/runtime-enforcer/templates/daemon/serviceaccount.yaml
+++ b/charts/runtime-enforcer/templates/daemon/serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "runtime-enforcer.fullname" . }}-daemon
-  labels:
-  {{- include "runtime-enforcer.labels" . | nindent 4 }}
-  annotations:
-    {{- toYaml .Values.daemon.serviceAccount.annotations | nindent 4 }}

--- a/charts/runtime-enforcer/tests/daemonset_test.yaml
+++ b/charts/runtime-enforcer/tests/daemonset_test.yaml
@@ -1,20 +1,20 @@
-suite: "Daemon DaemonSet Tests"
+suite: "Agent DaemonSet Tests"
 templates:
-  - "templates/daemon/daemonset.yaml"
+  - "templates/agent/daemonset.yaml"
 
 tests:
   - it: "should allow image, and imagePullPolicy to be overridden"
     set:
-      daemon:
-        daemon:
+      agent:
+        agent:
           image:
-            repository: somewhere/daemon
+            repository: somewhere/agent
             tag: v9.9.9
             pullPolicy: Always
     asserts:
       - equal:
           path: "spec.template.spec.containers[0].image"
-          value: "somewhere/daemon:v9.9.9"
+          value: "somewhere/agent:v9.9.9"
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"

--- a/charts/runtime-enforcer/tests/deployment_test.yaml
+++ b/charts/runtime-enforcer/tests/deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: "Daemon DaemonSet Tests"
+suite: "Agent DaemonSet Tests"
 templates:
   - "templates/operator/deployment.yaml"
 
@@ -9,7 +9,7 @@ tests:
         manager:
           replicas: 5
           image:
-            repository: somewhere/daemon
+            repository: somewhere/operator
             tag: v9.9.9
             pullPolicy: Always
     asserts:
@@ -18,7 +18,7 @@ tests:
           value: 5
       - equal:
           path: "spec.template.spec.containers[0].image"
-          value: "somewhere/daemon:v9.9.9"
+          value: "somewhere/operator:v9.9.9"
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -28,8 +28,8 @@ operator:
   replicas: 1
   serviceAccount:
     annotations: {}
-daemon:
-  daemon:
+agent:
+  agent:
     args:
     - ""
     containerSecurityContext:
@@ -54,7 +54,7 @@ daemon:
         drop:
           - ALL
     image:
-      repository: ghcr.io/neuvector/runtime-enforcer/daemon
+      repository: ghcr.io/neuvector/runtime-enforcer/agent
       tag: v0.0.2
       pullPolicy: IfNotPresent
     resources:

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -67,7 +67,7 @@ func newControllerManager() (manager.Manager, error) {
 	return mgr, nil
 }
 
-func startDaemon(ctx context.Context, logger *slog.Logger, config Config) error {
+func startAgent(ctx context.Context, logger *slog.Logger, config Config) error {
 	var err error
 
 	//////////////////////
@@ -201,7 +201,7 @@ func main() {
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
-	})).With("component", "daemon")
+	})).With("component", "agent")
 	slog.SetDefault(logger)
 
 	if config.enableTracing {
@@ -216,8 +216,8 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// This function blocks if everything is alright.
-	if err = startDaemon(ctx, logger, config); err != nil {
-		logger.ErrorContext(ctx, "failed to start daemon", "error", err)
+	if err = startAgent(ctx, logger, config); err != nil {
+		logger.ErrorContext(ctx, "failed to start agent", "error", err)
 		os.Exit(1)
 	}
 

--- a/docs/installation/quickstart.adoc
+++ b/docs/installation/quickstart.adoc
@@ -92,7 +92,7 @@ helm install runtime-enforcer ./charts/runtime-enforcer \
   --create-namespace \
   --set "imagePullSecrets[0].name=github-auth" \
   --set operator.manager.image.tag=latest \
-  --set daemon.daemon.image.tag=latest \
+  --set agent.agent.image.tag=latest \
   --set telemetry.mode=custom \
   --set telemetry.tracing=true \
   --set telemetry.custom.endpoint=http://otel-collector-opentelemetry-collector.otel-collector.svc.cluster.local:4317 \
@@ -112,7 +112,7 @@ Example output:
 
 ```bash
 runtime-enforcer   runtime-enforcer-controller-manager-bfbd8774d-bvjjn   1/1     Running
-runtime-enforcer   runtime-enforcer-daemon-lsxt4                         1/1     Running
+runtime-enforcer   runtime-enforcer-agent-lsxt4                         1/1     Running
 ```
 
 === Summary

--- a/docs/phases.adoc
+++ b/docs/phases.adoc
@@ -11,7 +11,7 @@ This document explains the three *phases* of runtime-enforcer and how to move be
 * For each learned executable, runtime-enforcer creates or updates a `WorkloadPolicyProposal` in the workload namespace and adds the executable path under `.spec.rulesByContainer[CONTAINER_NAME].executables.allowed`.
 
 
-NOTE: Learn is based on *exec events observed after the agent is running*. The daemon does *not* reconstruct what happened before it started.
+NOTE: Learn is based on *exec events observed after the agent is running*. The agent does *not* reconstruct what happened before it started.
 
 That means:
 

--- a/hack/Dockerfile.agent.tilt
+++ b/hack/Dockerfile.agent.tilt
@@ -1,0 +1,5 @@
+FROM alpine
+WORKDIR /
+COPY ./bin/agent /agent
+
+ENTRYPOINT ["/agent"]

--- a/hack/Dockerfile.daemon.tilt
+++ b/hack/Dockerfile.daemon.tilt
@@ -1,5 +1,0 @@
-FROM alpine
-WORKDIR /
-COPY ./bin/daemon /daemon
-
-ENTRYPOINT ["/daemon"]

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -11,10 +11,10 @@ COPY bpf/ /src/bpf/
 COPY internal/ /src/internal
 COPY go.mod go.sum /src/
 COPY Makefile /src/
-RUN make daemon
+RUN make agent
 
 FROM scratch
 WORKDIR /
-COPY --from=builder /src/bin/daemon /daemon
+COPY --from=builder /src/bin/agent /agent
 
-ENTRYPOINT ["/daemon"]
+ENTRYPOINT ["/agent"]

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 			"--mode",
 			"direct"),
 		envfuncs.LoadImageToCluster(kindClusterName,
-			"ghcr.io/neuvector/runtime-enforcer/daemon:latest",
+			"ghcr.io/neuvector/runtime-enforcer/agent:latest",
 			"--verbose",
 			"--mode",
 			"direct"),
@@ -101,7 +101,7 @@ func InstallRuntimeEnforcer() env.Func {
 			helm.WithNamespace(namespace),
 			helm.WithChart("../../charts/runtime-enforcer/"),
 			helm.WithArgs("--set", "operator.manager.image.tag=latest"),
-			helm.WithArgs("--set", "daemon.daemon.image.tag=latest"),
+			helm.WithArgs("--set", "agent.agent.image.tag=latest"),
 			helm.WithArgs("--set", "telemetry.mode=custom"),
 			helm.WithArgs("--set", "telemetry.tracing=true"),
 			helm.WithArgs(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,7 +49,7 @@ func IfRequiredResourcesAreCreated(ctx context.Context, t *testing.T, _ *envconf
 	err = wait.For(conditions.New(r).DaemonSetReady(
 		&appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "runtime-enforcer-daemon",
+				Name:      "runtime-enforcer-agent",
 				Namespace: namespace,
 			},
 		}),

--- a/tilt-settings.yaml.example
+++ b/tilt-settings.yaml.example
@@ -1,8 +1,8 @@
 operator: 
     image: <your-repository>/operator
     enforce-mode: # lsm or kprobe
-daemon: 
-    image: <your-repository>/daemon
+agent: 
+    image: <your-repository>/agent
     enable-otel-tracing: true/false
 clusters:
     - <your non-kind cluster>

--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -32,7 +32,7 @@ targets:
     spec:
       files:
         - package/Dockerfile.operator
-        - package/Dockerfile.daemon
+        - package/Dockerfile.agent
       instruction:
         keyword: FROM
         matcher: docker.io/library/golang

--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -78,11 +78,11 @@ targets:
     spec:
       file: charts/runtime-enforcer/values.yaml
       key: $.operator.manager.image.tag
-  update_daemon_version:
+  update_agent_version:
     scmid: default
-    name: Update Helm chart daemon version
+    name: Update Helm chart agent version
     kind: yaml
     sourceid: releaseVersion
     spec:
       file: charts/runtime-enforcer/values.yaml
-      key: $.daemon.daemon.image.tag
+      key: $.agent.agent.image.tag


### PR DESCRIPTION
We always refer to our policy enforcer running on the nodes as "agent", but the code called it "daemon".

This commit takes care of renaming the daemon to agent.

Notes about the tests that are not passing:
 - e2e tests: fails because we don't have NRI enabled by default yet, not related with this PR.
 - updatecli: fails because the `Dockerfile.agent` does not exist inside of the `main` branch.

Tilt environment works too.
