### PR TITLE
feat: support CronJob learning

### DIFF
--- a/internal/controller/workloadpolicyproposals_webhook.go
+++ b/internal/controller/workloadpolicyproposals_webhook.go
@@ -46,7 +46,7 @@ func (p *ProposalWebhook) updateResource(
 	case "Job":
 		res = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: ownerRef.Kind}
 	case "CronJob":
-		fallthrough
+		res = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: ownerRef.Kind}
 	default:
 		return fmt.Errorf("not supported resource type: %s", ownerRef.Kind)
 	}

--- a/test/e2e/learning_mode_test.go
+++ b/test/e2e/learning_mode_test.go
@@ -98,7 +98,14 @@ func getLearningModeTest() types.Feature {
 							return &job
 						},
 					},
-					// "ubuntu-cronjob.yaml",
+					"CronJob": {
+						ParseFunc: func() k8s.Object {
+							var cronjob batchv1.CronJob
+							err := decoder.DecodeFile(testdata, "ubuntu-cronjob.yaml", &cronjob)
+							require.NoError(t, err)
+							return &cronjob
+						},
+					},
 				}
 
 				for kind, tc := range testcases {

--- a/test/e2e/testdata/ubuntu-cronjob.yaml
+++ b/test/e2e/testdata/ubuntu-cronjob.yaml
@@ -10,10 +10,7 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
+          - name: ubuntu
             image: ubuntu
-            command:
-            - /bin/sh
-            - -c
-            - date; echo Hello
-          restartPolicy: OnFailure
+            command: ["bash", "-c", "sleep 5; ls"]
+          restartPolicy: Never


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Enable learning CronJob's behavior.  This also addresses the warning in main branch:

```
{"level":"error","ts":"2026-01-26T16:13:00Z","msg":"Reconciler error","controller":"learningEvent","reconcileID":"707ad8e9-5eba-4220-8795-d03a69d83ad9","error":"failed to run CreateOrUpdate: admission webhook \"workloadpolicyproposals.rancher.io\" denied the request: not supported resource type: CronJob","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:495\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:438\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/sam/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.0/pkg/internal/controller/controller.go:313"}
```

**Which issue(s) this PR fixes**

fixes #25 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
