### PR TITLE
chore: fix github repo stats ignoring vmlinux files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Exclude vmlinux from github stats
 bpf/vmlinux_generated_arm64.h linguist-vendored
-bpf/vmlinux_generated_x86_64.h linguist-vendored
+bpf/vmlinux_generated_x86.h linguist-vendored


### PR DESCRIPTION
the path for x86 was out of date

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

If you look at the current stats c code seems way more than Go code, but this is not true if we ignore the vmlinux files

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
