### PR TITLE
chore: make updatecli pass commitlint

### DIFF
--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -33,13 +33,13 @@ scms:
       branch: "{{ .github.branch }}"
       commitmessage:
         type: "chore"
-        title: "Update RuntimeEnforcer Helm charts"
+        title: "update runtime enforcer helm charts"
         hidecredit: true
         footers: "Signed-off-by: RuntimeEnforcer bot <runtime-enforcer-bot@users.noreply.github.com>"
 
 actions:
   default:
-    title: 'chore: Helm chart {{ source "chartVersion" }} release'
+    title: 'chore: helm chart {{ source "chartVersion" }} release'
     kind: github/pullrequest
     scmid: default
     spec:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

The commits created by updatecli for helm charts would fail commitlint.  This PR changes the subject of commits created by updatecli, so it can pass commitlint. 

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
