### PR TITLE
fix: sign commits generated by updatecli

### DIFF
--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -74,6 +74,7 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
+      commitusingapi: true
       commitmessage:
         type: "chore"
         scope: deps

--- a/updatecli/updatecli.release.d/helm-chart-update.yaml
+++ b/updatecli/updatecli.release.d/helm-chart-update.yaml
@@ -31,6 +31,7 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ requiredEnv .github.user }}"
       branch: "{{ .github.branch }}"
+      commitusingapi: true
       commitmessage:
         type: "chore"
         title: "update runtime enforcer helm charts"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Sign commits created by updatecli, so those PRs can be merged without ignoring PR requirement.

For golang update, I've verified it on https://github.com/holyspectral/runtime-enforcer/pull/3
For helm charts, let's verify it in the next release.

Currently we still use GITHUB_TOKEN.  We can move to GITHUB_APP later once this repository lands to where it should belong.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
