### PR TITLE
fix: safe shutdown of bpf manager

### DIFF
--- a/internal/bpf/cgroup_policy.go
+++ b/internal/bpf/cgroup_policy.go
@@ -31,7 +31,7 @@ func (op CgroupPolicyOperation) String() string {
 
 func (m *Manager) GetCgroupPolicyUpdateFunc() func(polID uint64, cgroupIDs []uint64, op CgroupPolicyOperation) error {
 	return func(polID uint64, cgroupIDs []uint64, op CgroupPolicyOperation) error {
-		return m.updateCgroupPolicy(polID, cgroupIDs, op)
+		return m.handleErrOnShutdown(m.updateCgroupPolicy(polID, cgroupIDs, op))
 	}
 }
 

--- a/internal/bpf/cgtracker.go
+++ b/internal/bpf/cgtracker.go
@@ -15,7 +15,7 @@ import (
 
 func (m *Manager) GetCgroupTrackerUpdateFunc() func(cgID uint64, cgroupPath string) error {
 	return func(cgID uint64, cgroupPath string) error {
-		return m.updateCgTrackerMap(cgID, cgroupPath)
+		return m.handleErrOnShutdown(m.updateCgTrackerMap(cgID, cgroupPath))
 	}
 }
 

--- a/internal/bpf/manager_test.go
+++ b/internal/bpf/manager_test.go
@@ -174,3 +174,44 @@ func TestMultiplePolicies(t *testing.T) {
 	err = manager.GetPolicyUpdateBinariesFunc()(mockPolicyID2, []string{"/usr/bin/who"}, AddValuesToPolicy)
 	require.NoError(t, err, "Failed to add policy 2 values")
 }
+
+func TestManagerShutdown(t *testing.T) {
+	manager, cleanup, err := waitRunningManager(t)
+	require.NoError(t, err, "Failed to start manager")
+	cleanup()
+
+	err = manager.GetPolicyUpdateBinariesFunc()(
+		uint64(100),
+		[]string{"/usr/bin/true", "/usr/bin/who"},
+		AddValuesToPolicy,
+	)
+	require.NoError(t, err, "bpf manager should return nil after shutdown")
+
+	err = manager.GetPolicyUpdateBinariesFunc()(
+		uint64(100),
+		[]string{"/usr/bin/true", "/usr/bin/who"},
+		ReplaceValuesInPolicy,
+	)
+	require.NoError(t, err, "bpf manager should return nil after shutdown")
+
+	err = manager.GetCgroupTrackerUpdateFunc()(
+		uint64(200),
+		"",
+	)
+	require.NoError(t, err, "bpf manager should return nil after shutdown")
+
+	err = manager.GetCgroupPolicyUpdateFunc()(
+		uint64(100),
+		[]uint64{200},
+		AddPolicyToCgroups,
+	)
+	require.NoError(t, err, "bpf manager should return nil after shutdown")
+
+	err = manager.GetCgroupPolicyUpdateFunc()(
+		uint64(100),
+		[]uint64{200},
+		RemovePolicy,
+	)
+
+	require.NoError(t, err, "bpf manager should return nil after shutdown")
+}

--- a/internal/bpf/policy_mode_operation.go
+++ b/internal/bpf/policy_mode_operation.go
@@ -45,9 +45,9 @@ func (m *Manager) GetPolicyModeUpdateFunc() func(policyID uint64, mode policymod
 	return func(policyID uint64, mode policymode.Mode, op PolicyModeOperation) error {
 		switch op {
 		case UpdateMode:
-			return m.updatePolicyMode(policyID, mode)
+			return m.handleErrOnShutdown(m.updatePolicyMode(policyID, mode))
 		case DeleteMode:
-			return m.deletePolicy(policyID)
+			return m.handleErrOnShutdown(m.deletePolicy(policyID))
 		default:
 			panic("unhandled policy mode")
 		}

--- a/internal/bpf/policy_values.go
+++ b/internal/bpf/policy_values.go
@@ -309,11 +309,11 @@ func (m *Manager) GetPolicyUpdateBinariesFunc() func(policyID uint64, values []s
 	return func(policyID uint64, values []string, op PolicyValuesOperation) error {
 		switch op {
 		case AddValuesToPolicy:
-			return m.generateBPFMaps(policyID, values)
+			return m.handleErrOnShutdown(m.generateBPFMaps(policyID, values))
 		case RemoveValuesFromPolicy:
-			return m.removeBPFMaps(policyID)
+			return m.handleErrOnShutdown(m.removeBPFMaps(policyID))
 		case ReplaceValuesInPolicy:
-			return m.replaceBPFMaps(policyID, values)
+			return m.handleErrOnShutdown(m.replaceBPFMaps(policyID, values))
 		default:
 			panic("unhandled operation")
 		}


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

1. Add a flag to indicate bpf manager is already shutdown.
2. Make bpf manager's functions return nil error if the bpf manager is already shutdown.

**Which issue(s) this PR fixes**

fixes #112 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
