### PR TITLE
fix: keep version comments in pre-commit config

### DIFF
--- a/updatecli/updatecli.d/pre-commit.yaml
+++ b/updatecli/updatecli.d/pre-commit.yaml
@@ -74,6 +74,8 @@ targets:
     sourceid: golangcilintVersion
     spec:
       file: .pre-commit-config.yaml
+      comment: '{{ source "golangcilintTag" }}'
+      engine: yamlpath
       key: $.repos[0].rev
   update_clangformat_version:
     scmid: default
@@ -83,3 +85,5 @@ targets:
     spec:
       file: .pre-commit-config.yaml
       key: $.repos[1].rev
+      comment: '{{ source "clangformatTag" }}'
+      engine: yamlpath


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

In the previous versions, when pre-commit config is updated, there is no version comments attached to the hash.  
This PR fixes the issue. 

After the change, the PR can be seen here: https://github.com/holyspectral/runtime-enforcer/pull/6/changes

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
