### PR TITLE
fix: remove owner reference from workload policy

### DIFF
--- a/internal/controller/workloadpolicyproposal_controller.go
+++ b/internal/controller/workloadpolicyproposal_controller.go
@@ -61,11 +61,6 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 
 	_, err = controllerutil.CreateOrPatch(ctx, r.Client, &policy, func() error {
 		policy.Spec = policyProposal.Spec.IntoWorkloadPolicySpec()
-
-		err = controllerutil.SetControllerReference(&policyProposal, &policy, r.Scheme)
-		if err != nil {
-			return fmt.Errorf("failed to set controller reference: %w", err)
-		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

When a policy is promoted from a policy proposal, we don't want it have the owner reference to the policy proposal, so the policy can stay alive without the policy proposal.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
