### PR TITLE
feat: stop agent if it fails to parse cgroup path

### DIFF
--- a/internal/nri/handler.go
+++ b/internal/nri/handler.go
@@ -93,6 +93,7 @@ func (h *Handler) startNRIPlugin(ctx context.Context) error {
 		h.logger,
 		h.resolver,
 		stub.WithLogger(newNRILogger(h.logger)),
+		stub.WithPluginName("runtime-enforcer-agent"),
 		stub.WithPluginIdx(h.pluginIndex),
 		stub.WithSocketPath(h.socketPath),
 	)
@@ -102,6 +103,11 @@ func (h *Handler) startNRIPlugin(ctx context.Context) error {
 
 	err = p.Run(ctx)
 	if err != nil {
+		if p.lastErr != nil {
+			// We use the lastErr whenever possible, because the error returned by p.Run()
+			// is usually not very helpful, e.g., `ttrpc: server closed`.
+			err = p.lastErr
+		}
 		return fmt.Errorf("NRI plugin exited with error: %w", err)
 	}
 	return nil

--- a/internal/nri/plugin.go
+++ b/internal/nri/plugin.go
@@ -2,9 +2,11 @@ package nri
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
+	retry "github.com/avast/retry-go/v4"
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/stub"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/resolver"
@@ -15,6 +17,7 @@ type plugin struct {
 	stub     stub.Stub
 	logger   *slog.Logger
 	resolver *resolver.Resolver
+	lastErr  error
 }
 
 func (p *plugin) getWorkloadInfoAndLog(ctx context.Context, pod *api.PodSandbox) (string, workloadkind.Kind) {
@@ -42,11 +45,17 @@ func (p *plugin) Synchronize(
 	for _, container := range containers {
 		cgroupID, err := cgroupFromContainer(container)
 		if err != nil {
-			// this should never happen but if we are not able to obtain the cgroup ID, it's useless to add the container
-			// to the cache, nobody will ever query this entry into the cache
-			p.logger.ErrorContext(ctx, "failed to get cgroup ID from container",
+			// When this happens, we can't retrieve the cgroup ID in the target system.
+			// This is a critical error.
+			// 
+			// By returning a retry.Unrecoverable error, we allow our retry logic in Handler.Start() to
+			// skip the retries and abort immediately.
+			p.lastErr = retry.Unrecoverable(fmt.Errorf("failed to synchronize NRI plugin: %w", err))
+
+			// Container runtime will log this. We log here too for convenience. 
+			p.logger.ErrorContext(ctx, "failed to synchronize NRI plugin",
 				"error", err)
-			continue
+			return nil, p.lastErr
 		}
 
 		// Populate the sandbox map


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Currently when we fail to get cgroup ID, we leave a log, and then ignore it silently and left those containers with no protection.

This PR changes the behavior.  From now on, when we fail to parse the initial container in Synchronize call from NRI plugin, we fail immediately. 

**Which issue(s) this PR fixes**

fixes #120 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
