### PR TITLE
refactor: move cgroup path check in init function

### DIFF
--- a/internal/cgroups/cgroups.go
+++ b/internal/cgroups/cgroups.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 
 	"go.uber.org/multierr"
@@ -36,6 +35,18 @@ const (
 	// todo!: make this configurable.
 	defaultProcFSPath = "/proc"
 )
+
+var (
+	cgroupRootPath string //nolint:gochecknoglobals // we want it global.
+)
+
+//nolint:gochecknoinits // this seems the best place to initialize it since it can be used by different packages.
+func init() {
+	var err error
+	if cgroupRootPath, err = detectHostCgroupRoot(); err != nil {
+		panic(fmt.Sprintf("failed to detect host cgroup root: %v", err))
+	}
+}
 
 type FileHandle struct {
 	ID uint64
@@ -211,25 +222,12 @@ func detectCgroupFSMagic(cgroupRoot string) (uint64, error) {
 	}
 }
 
-var (
-	cgroupRootCheckOnce sync.Once //nolint:gochecknoglobals // we want it global for a global function.
-	cgroupRootPath      string    //nolint:gochecknoglobals // we want it global for a global function.
-	errCgroupRootPath   error
-)
-
-// GetHostCgroupRoot tries to retrieve the host cgroup root
-//
-// for now we are checking /sys/fs/cgroup under host /proc's init.
-// For systems where the cgroup is mounted in a non-standard location, we could
-// also check host's /proc/mounts.
-func GetHostCgroupRoot() (string, error) {
-	cgroupRootCheckOnce.Do(func() {
-		cgroupRootPath, errCgroupRootPath = getHostCgroupRoot()
-	})
-	return cgroupRootPath, errCgroupRootPath
+// GetHostCgroupRoot returns the global variable set by init func.
+func GetHostCgroupRoot() string {
+	return cgroupRootPath
 }
 
-func getHostCgroupRoot() (string, error) {
+func detectHostCgroupRoot() (string, error) {
 	var multiErr error
 
 	// We first try /proc/1/root/sys/fs/cgroup/
@@ -261,10 +259,7 @@ func getHostCgroupRoot() (string, error) {
 // GetCgroupInfo retrieves cgroup information such as cgroup root, fs magic and subsys index.
 func GetCgroupInfo(logger *slog.Logger) (*CgroupInfo, error) {
 	// We first need to find the host cgroup root. We still don't know if it is v1 or v2.
-	cgroupRoot, err := GetHostCgroupRoot()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get host cgroup root: %w", err)
-	}
+	cgroupRoot := GetHostCgroupRoot()
 
 	// Understand cgroupfs magic
 	cgroupFsMagic, err := detectCgroupFSMagic(cgroupRoot)

--- a/internal/nri/extract.go
+++ b/internal/nri/extract.go
@@ -34,7 +34,7 @@ func cgroupFromContainer(container *api.Container) (resolver.CgroupID, error) {
 		)
 	}
 
-	cgRoot, _ := cgroups.GetHostCgroupRoot()
+	cgRoot := cgroups.GetHostCgroupRoot()
 	path := filepath.Join(cgRoot, parsedPath)
 
 	// Get the cgroup ID


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves the host cgroup root path check in init function

**Which issue(s) this PR fixes**

ref #120 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
