### PR TITLE
docs: don't use latest tag in quickstart

### DIFF
--- a/docs/installation/quickstart.adoc
+++ b/docs/installation/quickstart.adoc
@@ -90,8 +90,6 @@ helm repo update
 helm install runtime-enforcer runtime-enforcer/runtime-enforcer \
   --namespace runtime-enforcer \
   --create-namespace \
-  --set operator.manager.image.tag=latest \
-  --set agent.agent.image.tag=latest \
   --set telemetry.mode=custom \
   --set telemetry.tracing=true \
   --set telemetry.custom.endpoint=http://otel-collector-opentelemetry-collector.otel-collector.svc.cluster.local:4317 \


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

today `latest` tag points to the  image built on top of main, so if we try to use it with a released Helm chart version, we could have issues, since main could be incompatible with old chart versions. Maybe we could change the name of the tag into `main`

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
