### PR TITLE
fix: mount nri folder instead of socket

### DIFF
--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -74,7 +74,7 @@ spec:
         securityContext: {{- toYaml .Values.agent.agent.containerSecurityContext | nindent 10 }}
         volumeMounts:
         - name: nri-socket
-          mountPath: /var/run/nri/nri.sock
+          mountPath: /var/run/nri/
           mountPropagation: HostToContainer
           readOnly: true
         - name: grpc-certs

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -72,7 +72,7 @@ agent:
       type: RuntimeDefault
   serviceAccount:
     annotations: {}
-  nriSocketPath: /var/run/nri/nri.sock
+  nriSocketPath: /var/run/nri/
 kubernetesClusterDomain: cluster.local
 
 ## Optional array of imagePullSecrets containing private registry credentials


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

When containerd restarts, it creates a new unix socket.  If we mounted the socket directly when agent starts, the socket in agent container will not be updated, so agent will keep failing to reconnect with below error and wouldn't recover.

```
time="2026-02-13T17:37:06Z" level=info msg="Created plugin 00-runtime-enforcer-agent (agent, handles StartContainer,RemoveContainer)"
time=2026-02-13T17:37:06.843Z level=WARN msg="error during NRI plugin execution, retrying..." component=agent component=nri-handler attempt=8 error="NRI plugin exited with error: failed to connect to NRI service: dial unix /var/run/nri/nri.sock: connect: connection refused"
```

When we check the inode of socket after the issue happens, the #inode on host and agent container will be different, which means now they're two files now. 

```
<host>
# ls -i /var/run/nri/nri.sock 
6557 /var/run/nri/nri.sock

<container>
# ls -i /var/run/nri/nri.sock 
6165 /var/run/nri/nri.sock
```

This issue is fixed by mounting the NRI folder instead.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
