### PR TITLE
feat: give more time for the startup probe

### DIFF
--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -68,8 +68,10 @@ spec:
           httpGet:
             path: /readyz
             port: 8081
+          # we give 45s (5s delay + 8 attempts every 5s) for the startup probe to succeed
           initialDelaySeconds: 5
-          periodSeconds: 3
+          periodSeconds: 5
+          failureThreshold: 8
         resources: {{- toYaml .Values.agent.agent.resources | nindent 10 }}
         securityContext: {{- toYaml .Values.agent.agent.containerSecurityContext | nindent 10 }}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:

Today, if the agent is not ready in 14 seconds, we kill it. 14 seconds seems not to be enough in some situations when EBPF loading could take some time. We are actually hitting this issue in our demo-dev cluster. 
This PR bumps this limit to 45 seconds (5 of the initial delay + 5*8). This should be more than enough in almost all cases

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
