### PR TITLE
feat: use slog adapter for NRI stub messages

### DIFF
--- a/internal/nri/handler.go
+++ b/internal/nri/handler.go
@@ -92,6 +92,7 @@ func (h *Handler) startNRIPlugin(ctx context.Context) error {
 	p, err := newNRIPlugin(
 		h.logger,
 		h.resolver,
+		stub.WithLogger(newNRILogger(h.logger)),
 		stub.WithPluginIdx(h.pluginIndex),
 		stub.WithSocketPath(h.socketPath),
 	)

--- a/internal/nri/logger.go
+++ b/internal/nri/logger.go
@@ -1,0 +1,34 @@
+package nri
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	nrilog "github.com/containerd/nri/pkg/log"
+)
+
+// nriLogger adapts slog to the NRI log interface so stub messages are emitted as JSON.
+type nriLogger struct {
+	logger *slog.Logger
+}
+
+func newNRILogger(logger *slog.Logger) nrilog.Logger {
+	return &nriLogger{logger: logger.With("component", "nri-stub")}
+}
+
+func (s *nriLogger) Debugf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.DebugContext(ctx, fmt.Sprintf(format, args...))
+}
+
+func (s *nriLogger) Infof(ctx context.Context, format string, args ...interface{}) {
+	s.logger.InfoContext(ctx, fmt.Sprintf(format, args...))
+}
+
+func (s *nriLogger) Warnf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.WarnContext(ctx, fmt.Sprintf(format, args...))
+}
+
+func (s *nriLogger) Errorf(ctx context.Context, format string, args ...interface{}) {
+	s.logger.ErrorContext(ctx, fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
The NRI stub is using logrus, so we'll see the following inconsistent logs in agent
`time="2026-02-14T02:45:15Z" level=info msg="Created plugin 00-agent (agent, handless StartContainer,RemoveContainer)"`
`time="2026-02-14T02:45:15Z" level=info msg="Registering plugin 00-agent..."`
`time="2026-02-14T02:45:15Z" level=info msg="Configuring plugin 00-agent for runtime containerd/v2.1.3..."`
`time="2026-02-14T02:45:15Z" level=info msg="Started plugin 00-agent..."`

I'm implementing an NRI logger adapter that will forward to slog with JSON format.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
