### PR TITLE
feat(helm): allow users to configure PodDisruptionBudgets

### DIFF
--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -20,6 +20,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: agent
     spec:
+      {{- if .Values.priorityClass.name }}
+      priorityClassName: {{ .Values.priorityClass.name }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/runtime-enforcer/templates/operator/deployment.yaml
+++ b/charts/runtime-enforcer/templates/operator/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     control-plane: controller-manager
   {{- include "runtime-enforcer.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.operator.manager.replicas }}
+  replicas: {{ .Values.operator.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: operator
@@ -19,6 +19,9 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      {{- if .Values.priorityClass.name }}
+      priorityClassName: {{ .Values.priorityClass.name }}
+      {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/runtime-enforcer/templates/operator/pdb.yaml
+++ b/charts/runtime-enforcer/templates/operator/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.operator.pdb .Values.operator.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "runtime-enforcer.fullname" . }}-controller-manager
+  labels:
+    {{- include "runtime-enforcer.labels" . | nindent 4 }}
+spec:
+  {{- $pdbSpec := omit .Values.operator.pdb "enabled" }}
+  {{- $pdbSpec | toYaml | nindent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: operator
+      {{- include "runtime-enforcer.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/runtime-enforcer/templates/priorityclass/priorityclass.yaml
+++ b/charts/runtime-enforcer/templates/priorityclass/priorityclass.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.priorityClass.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClass.name }}
+  labels:
+    {{- include "runtime-enforcer.labels" . | nindent 4 }}
+{{- $pcSpec := omit .Values.priorityClass "enabled" "name" }}
+{{- $pcSpec | toYaml | nindent 0 }}
+{{- end }}

--- a/charts/runtime-enforcer/tests/daemonset_test.yaml
+++ b/charts/runtime-enforcer/tests/daemonset_test.yaml
@@ -18,6 +18,9 @@ tests:
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"
+      - equal:
+          path: "spec.template.spec.priorityClassName"
+          value: "runtime-enforcer-priorityclass"
 
   - it: "should include --enable-learning flag when learning is enabled"
     set:

--- a/charts/runtime-enforcer/tests/deployment_test.yaml
+++ b/charts/runtime-enforcer/tests/deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: "Agent DaemonSet Tests"
+suite: "Operator Deployment Tests"
 templates:
   - "templates/operator/deployment.yaml"
 
@@ -6,8 +6,8 @@ tests:
   - it: "should allow image, and imagePullPolicy to be overridden"
     set:
       operator:
+        replicas: 5
         manager:
-          replicas: 5
           image:
             repository: somewhere/operator
             tag: v9.9.9
@@ -22,6 +22,9 @@ tests:
       - equal:
           path: "spec.template.spec.containers[0].imagePullPolicy"
           value: "Always"
+      - equal:
+          path: "spec.template.spec.priorityClassName"
+          value: "runtime-enforcer-priorityclass"
 
   - it: "should include grpc Port argument"
     set:

--- a/charts/runtime-enforcer/tests/pdb_test.yaml
+++ b/charts/runtime-enforcer/tests/pdb_test.yaml
@@ -1,0 +1,41 @@
+suite: "Operator PDB Tests"
+templates:
+  - "templates/operator/pdb.yaml"
+
+tests:
+  - it: "should not render PDB when disabled by default"
+    set: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "should render PDB with expected name and minAvailable when enabled"
+    set:
+      operator:
+        pdb:
+          enabled: true
+          minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - matchRegex:
+          path: metadata.name
+          pattern: ".*-controller-manager$"
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: "should render PDB and allow minAvailable override"
+    set:
+      operator:
+        pdb:
+          enabled: true
+          minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -14,19 +14,28 @@ operator:
       repository: ghcr.io/rancher-sandbox/runtime-enforcer/operator
       tag: v0.1.0
       pullPolicy: IfNotPresent
+    # To make the Pods "Guaranteed" (evicted last under node pressure), kubelet requires
+    # requests and limits are specified for all the containers and they are equal.
+    # Please refer to https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction
     resources:
       limits:
         cpu: 500m
         memory: 128Mi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 500m
+        memory: 128Mi
     wpStatusUpdateInterval: 30s
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
   replicas: 1
+  # # PodDisruptionBudget for the operator Deployment. Disable by default.
+  # # When enabled, limits voluntary disruption (e.g. kubectl drain).
+  # pdb:
+  #   enabled: false
+  #   # minAvailable: at least 1 pod must stay available during a disruption.
+  #   minAvailable: 1
   serviceAccount:
     annotations: {}
   tolerations: []
@@ -62,13 +71,16 @@ agent:
     grpcExporterPort: "50051"
     # agent logger level. Can be one of: debug, info, warn, error.
     logLevel: info
+    # To make the Pods "Guaranteed" (evicted last under node pressure), kubelet requires
+    # requests and limits are specified for all the containers and they are equal.
+    # Please refer to https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#pod-selection-for-kubelet-eviction
     resources:
       limits:
         cpu: 500m
         memory: 128Mi
       requests:
-        cpu: 10m
-        memory: 64Mi
+        cpu: 500m
+        memory: 128Mi
   hostPID: true
   podSecurityContext:
     seccompProfile:
@@ -133,3 +145,11 @@ telemetry:
 # Requires Kubernetes 1.25+ for ValidatingAdmissionPolicy support
 vap:
   enabled: true
+
+# PriorityClass shared by both operator and agent pods.
+priorityClass:
+  enabled: true
+  name: runtime-enforcer-priorityclass
+  value: 1000000
+  globalDefault: false
+  description: PriorityClass for runtime-enforcer operator and agent pods.


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Allow users to configure PodDisruptionBudgets for agent DaemonSet and operator Deployment.
This PR also fixed one bug as the `replicas` lives under `operator`, not `operator.manager`

**Which issue(s) this PR fixes**

fixes #277 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
