### PR TITLE
feat: enable arm support

### DIFF
--- a/.github/workflows/bpf_test.yml
+++ b/.github/workflows/bpf_test.yml
@@ -7,11 +7,16 @@ on:
 jobs:
   test:
     name: test-${{ matrix.arch }}
-    runs-on: ${{ (matrix.arch == 'arm64' && 'ubuntu-24.04-arm') || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -14,11 +14,12 @@ jobs:
     strategy:
       matrix:
         component: [operator, agent]
-        arch: [amd64]
+        arch: [amd64, arm64]
         include:
           - arch: amd64
             runner: ubuntu-latest
-            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write # Pushing images to ghcr.io
@@ -51,7 +52,7 @@ jobs:
       - name: Merge images
         uses: ./.github/actions/merge-multiarch
         with:
-          arch: amd64
+          arch: amd64,arm64
           image: ${{ matrix.component }}
           repo: ${{ github.repository }}
           tag: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,12 @@ jobs:
     strategy:
       matrix:
         component: [operator, agent]
-        arch: [amd64]
+        arch: [amd64, arm64]
         include:
           - arch: amd64
             runner: ubuntu-latest
-            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read # Access private repos
       packages: write
@@ -47,7 +48,7 @@ jobs:
       - name: Merge images
         uses: ./.github/actions/merge-multiarch
         with:
-          arch: amd64
+          arch: amd64,arm64
           image: ${{ matrix.component }}
           repo: ${{ github.repository }}
           tag: ${{ github.ref_name }}
@@ -57,11 +58,14 @@ jobs:
     strategy:
       matrix:
         component: [operator, agent]
-        arch: [amd64]
+        arch: [amd64, arm64]
         include:
           - arch: amd64
             runner: ubuntu-latest
             platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
     needs: [merge]
     permissions:
       contents: read # Access private repos
@@ -129,6 +133,15 @@ jobs:
                 'RuntimeEnforcer-operator-attestation-amd64-provenance.intoto.jsonl.bundle.sigstore',
                 'RuntimeEnforcer-operator-attestation-amd64-sbom.json',
                 'RuntimeEnforcer-operator-attestation-amd64-sbom.json.bundle.sigstore',
+
+                'RuntimeEnforcer-agent-attestation-arm64-provenance.intoto.jsonl',
+                'RuntimeEnforcer-agent-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+                'RuntimeEnforcer-agent-attestation-arm64-sbom.json',
+                'RuntimeEnforcer-agent-attestation-arm64-sbom.json.bundle.sigstore',
+                'RuntimeEnforcer-operator-attestation-arm64-provenance.intoto.jsonl',
+                'RuntimeEnforcer-operator-attestation-arm64-provenance.intoto.jsonl.bundle.sigstore',
+                'RuntimeEnforcer-operator-attestation-arm64-sbom.json',
+                'RuntimeEnforcer-operator-attestation-arm64-sbom.json.bundle.sigstore',
                 ]
             const {RELEASE_ID} = process.env
             for (const file of files) {

--- a/bpfvalidator-arm64-config.yaml
+++ b/bpfvalidator-arm64-config.yaml
@@ -1,0 +1,9 @@
+# Number of parallel VMs to run
+parallel: 3
+# kernel versions to test
+kernel_versions:
+    - v6.4
+    - v6.6.119
+    - v6.12.62
+      #- v6.17.12 # disabled due to qemu's "unable to handle EFI zboot image with "zstd" compression" error
+      #- v6.18.1 # disabled due to qemu's "unable to handle EFI zboot image with "zstd" compression" error

--- a/docs/compatibility.adoc
+++ b/docs/compatibility.adoc
@@ -15,11 +15,11 @@ Runtime Enforcer uses eBPF (Extended Berkeley Packet Filter) to monitor and enfo
 |Component |Version/Requirement |Notes
 
 |*Minimum Kernel*
-|5.8
+|5.8 (x86_64), 6.4 (aarch64)
 |Limitation: max binary path length in policies is 512 characters. Starting from kernel 5.11, this limitation no longer applies, paths can be up to 4096 characters.
 
 |*Architecture*
-|x86_64
+|x86_64, aarch64
 |Fully supported
 
 |*Cgroup*


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

- Build arm64 build for main branch.
- Enable bpfvalidator to run on arm system
- Release multi-arch images for arm.
- Publish arm64 attestation.

Note:
- kernels prior to 6.4 is considered as not supported.  
- qemu can't boot newer arm64 kernels compressed with zstd and [the fix](https://github.com/qemu/qemu/commit/3a18e8a25992d1643707e2cebdd6e9bb2bd7d3b9) was already merged.  We have to wait until qemu does a release, so we can revisit later. 

**Tests done**:

The successful run for main branch build: https://github.com/holyspectral/runtime-enforcer/actions/runs/22197138869
The successful build for release: https://github.com/holyspectral/runtime-enforcer/actions/runs/22197148359

The image from the main branch:
- https://github.com/holyspectral/runtime-enforcer/pkgs/container/runtime-enforcer%2Fagent/695817728?tag=latest
- https://github.com/holyspectral/runtime-enforcer/pkgs/container/runtime-enforcer%2Foperator/695817813?tag=latest

The release artifacts:
- https://github.com/holyspectral/runtime-enforcer/pkgs/container/runtime-enforcer%2Fagent/695818595?tag=v0.9.0
- https://github.com/holyspectral/runtime-enforcer/pkgs/container/runtime-enforcer%2Foperator/695818639?tag=v0.9.0

**Which issue(s) this PR fixes**

fixes #27 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
