### PR TITLE
chore: fix gofmt and linter issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,12 @@ repos:
   - repo: https://github.com/golangci/golangci-lint
     rev: 5d1e709b7be35cb2025444e19de266b056b7b7ee # v2.10.1
     hooks:
-      - id: golangci-lint
-        stages: [pre-commit]
+      - id: golangci-lint-full
         language_version: 1.26.0
+        stages: [pre-commit]
+      - id: golangci-lint-fmt
+        language_version: 1.26.0
+        stages: [pre-commit]
   - repo: https://github.com/cpp-linter/cpp-linter-hooks
     rev: 2e3490dedce400711609720c51d7e31bba764c08 # v1.1.12
     hooks:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -129,7 +129,7 @@ func SetupControllers(logger logr.Logger,
 	}
 
 	var wpStatusSync *controller.WorkloadPolicyStatusSync
-	if wpStatusSync, err = controller.NewWorkloadPolicyStatusSync(mgr.GetClient(), wpStatusSyncConf);err != nil {
+	if wpStatusSync, err = controller.NewWorkloadPolicyStatusSync(mgr.GetClient(), wpStatusSyncConf); err != nil {
 		return fmt.Errorf("unable to create WorkloadPolicyStatusSync: %w", err)
 	}
 	if err = mgr.Add(wpStatusSync); err != nil {

--- a/internal/bpf/policy_values.go
+++ b/internal/bpf/policy_values.go
@@ -218,11 +218,16 @@ func (m *Manager) generateBPFMaps(policyID uint64, values []string) error {
 	isPre5_9 := m.isKernelPre5_9()
 	for i := range subMaps {
 		// if the subMap is empty we skip it
-		if len(subMaps[i]) == 0 {
+		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
 			continue
 		}
 
-		if err = m.generateInnerBPFMaps(policyID, i, isPre5_9, subMaps[i]); err != nil {
+		if err = m.generateInnerBPFMaps(
+			policyID,
+			i,
+			isPre5_9,
+			subMaps[i], //nolint:gosec // false positive
+		); err != nil {
 			return err
 		}
 	}
@@ -246,7 +251,7 @@ func (m *Manager) replaceBPFMaps(policyID uint64, values []string) error {
 
 	isPre5_9 := m.isKernelPre5_9()
 	for i := range subMaps {
-		if len(subMaps[i]) == 0 {
+		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
 			// No values for this size bucket - delete the old inner map if it exists
 			if err = m.policyStringMaps[i].Delete(policyID); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 				return fmt.Errorf("failed to remove policy (id=%d) from map %s: %w",
@@ -256,7 +261,7 @@ func (m *Manager) replaceBPFMaps(policyID uint64, values []string) error {
 		}
 
 		// Create and populate new inner map, then atomically replace
-		if err = m.replaceInnerBPFMap(policyID, i, isPre5_9, subMaps[i]); err != nil {
+		if err = m.replaceInnerBPFMap(policyID, i, isPre5_9, subMaps[i]); err != nil { //nolint:gosec // false positive
 			return err
 		}
 	}

--- a/internal/controller/workloadpolicystatus_test.go
+++ b/internal/controller/workloadpolicystatus_test.go
@@ -122,7 +122,7 @@ func TestComputeWpStatus(t *testing.T) {
 			},
 			expected: v1alpha1.WorkloadPolicyStatus{
 				NodesWithIssues: map[string]v1alpha1.NodeIssue{
-					node1: v1alpha1.NodeIssue{Code: v1alpha1.NodeIssueMissingPolicy},
+					node1: {Code: v1alpha1.NodeIssueMissingPolicy},
 				},
 				TotalNodes:         3,
 				SuccessfulNodes:    1,

--- a/internal/nri/plugin.go
+++ b/internal/nri/plugin.go
@@ -47,12 +47,12 @@ func (p *plugin) Synchronize(
 		if err != nil {
 			// When this happens, we can't retrieve the cgroup ID in the target system.
 			// This is a critical error.
-			// 
+			//
 			// By returning a retry.Unrecoverable error, we allow our retry logic in Handler.Start() to
 			// skip the retries and abort immediately.
 			p.lastErr = retry.Unrecoverable(fmt.Errorf("failed to synchronize NRI plugin: %w", err))
 
-			// Container runtime will log this. We log here too for convenience. 
+			// Container runtime will log this. We log here too for convenience.
 			p.logger.ErrorContext(ctx, "failed to synchronize NRI plugin",
 				"error", err)
 			return nil, p.lastErr


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Just noticed that many golang linters actually do not run because we run a fast mode.  

This PR does a few things:
- Add golangci-lint-fmt into pre-commit, so it catches gofmt issues.
- Fix the existing gofmt issues.
- Moving to golangci-lint-full in pre-commit.
- Fix the linter issues (but most are false positives from https://github.com/securego/gosec/issues/1525)

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
