### PR TITLE
fix(chart): do not remove our CRDS at uninstall time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) rbac:roleName=agent-role paths="./cmd/agent" paths="./internal/eventhandler" output:rbac:artifacts:config=charts/runtime-enforcer/templates/agent
 	sed -i 's/operator-role/{{ include "runtime-enforcer.fullname" . }}-operator/' charts/runtime-enforcer/templates/operator/role.yaml
 	sed -i 's/agent-role/{{ include "runtime-enforcer.fullname" . }}-agent/' charts/runtime-enforcer/templates/agent/role.yaml
+	for f in ./charts/runtime-enforcer/templates/crd/*.yaml; do \
+		sed -i '/^[[:space:]]*annotations:/a\    helm.sh\/resource-policy: keep' "$$f"; \
+	done
 
 REPO ?= ghcr.io/rancher-sandbox/runtime-enforcer
 TAG ?= latest

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.17.1
   name: workloadpolicies.security.rancher.io
 spec:

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicyproposals.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicyproposals.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.17.1
   name: workloadpolicyproposals.security.rancher.io
 spec:

--- a/docs/installation/uninstall.adoc
+++ b/docs/installation/uninstall.adoc
@@ -6,7 +6,18 @@ You can remove the Runtime-Enforcer and all the policies created by uninstalling
 helm uninstall runtime-enforcer --namespace runtime-enforcer
 ```
 
-Please note that this command will delete all existing WorkloadPolicy and WorkloadPolicyProposal in an irreversible way.
+Please note that this command will not delete the existing WorkloadPolicy and WorkloadPolicyProposal.
+
+To remove them, you can run the following commands:
+
+```bash
+kubectl get workloadpolicies.security.rancher.io --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers | while read name namespace; do
+  kubectl patch workloadpolicies.security.rancher.io $name -n $namespace --type=merge -p '{"metadata":{"finalizers":[]}}'
+done
+
+kubectl delete crd workloadpolicies.security.rancher.io
+kubectl delete crd workloadpolicyproposals.security.rancher.io
+```
 
 Finally, delete the namespace where Runtime-Enforcer was deployed:
 


### PR DESCRIPTION
Instruct helm to not remove the WorkloadPolicy and WorkloadPolicyProposal at uninstall time.

There are two reasons for doing that:

- Do not let users lose their WorkloadPolicy definitions by mistake, when doing a quick uninstall & install cycle.
- Do not let helm uninstall hang

About the latter point. Our WorkloadPolicy objects have a finalizer set by us. This is done to prevent a user to remove a policy that is in use by a workload. However, when the user uninstalls our helm chart, the controller in charge of removing the finalizer doesn't exists anymore.
Because of that, the removal of all the WorkloadPolicy is stuck, causing helm uninstall to hang.

With this change, helm uninstall does not hang. It's up to the user to deliberately remove the CRDs manually, by following our documentation.
