### PR TITLE
fix: shutdown nri plugin

### DIFF
--- a/internal/bpf/manager.go
+++ b/internal/bpf/manager.go
@@ -228,12 +228,12 @@ func (m *Manager) handleErrOnShutdown(err error) error {
 
 func (m *Manager) Start(ctx context.Context) error {
 	defer func() {
-		m.logger.InfoContext(ctx, "BPF Manager stopped")
 		m.isShuttingDown.Store(true)
 
 		if err := m.objs.Close(); err != nil {
 			m.logger.ErrorContext(ctx, "failed to close BPF objects", "error", err)
 		}
+		m.logger.InfoContext(ctx, "BPF Manager stopped")
 	}()
 
 	m.logger.InfoContext(ctx, "Starting BPF Manager...")

--- a/internal/eventscraper/eventscraper.go
+++ b/internal/eventscraper/eventscraper.go
@@ -106,6 +106,10 @@ func (es *EventScraper) getKubeProcessInfo(event *bpf.ProcessEvent) *KubeProcess
 
 // Start begins the event scraping process.
 func (es *EventScraper) Start(ctx context.Context) error {
+	defer func() {
+		es.logger.InfoContext(ctx, "event scraper has stopped")
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/grpcexporter/server.go
+++ b/internal/grpcexporter/server.go
@@ -117,6 +117,9 @@ func New(logger *slog.Logger, conf *Config, resolver *resolver.Resolver) (*Serve
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	defer func() {
+		s.logger.InfoContext(ctx, "grpcexporter has stopped")
+	}()
 	lc := net.ListenConfig{}
 	addr := fmt.Sprintf(":%d", s.conf.Port)
 	listener, err := lc.Listen(ctx, "tcp", addr)

--- a/internal/nri/handler.go
+++ b/internal/nri/handler.go
@@ -39,7 +39,22 @@ func newNRIPlugin(logger *slog.Logger, resolver *resolver.Resolver, opts ...stub
 }
 
 func (p *plugin) Run(ctx context.Context) error {
-	return p.stub.Run(ctx)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.stub.Stop()
+		case <-done:
+		}
+	}()
+
+	err := p.stub.Run(ctx)
+	close(done) // prevent goroutine leak if Run() returns naturally
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return err
 }
 
 func NewNRIHandler(socketPath, pluginIndex string, logger *slog.Logger, r *resolver.Resolver) (*Handler, error) {
@@ -114,6 +129,10 @@ func (h *Handler) startNRIPlugin(ctx context.Context) error {
 }
 
 func (h *Handler) Start(ctx context.Context) error {
+	defer func() {
+		h.logger.InfoContext(ctx, "NRI handler has stopped")
+	}()
+
 	// isRetryable is called only in case of err != nil
 	isRetryable := func(err error) bool {
 		// We stop in case of:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR makes sure that NRI plugin shuts down correctly when control manager stops.  Some info-level logs are also added to help us to diagnose the issue if it happens again.

**Which issue(s) this PR fixes**

fixes #311 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
