### PR TITLE
fix: fix linter check warning

### DIFF
--- a/internal/bpf/policy_values.go
+++ b/internal/bpf/policy_values.go
@@ -216,9 +216,9 @@ func (m *Manager) generateBPFMaps(policyID uint64, values []string) error {
 	}
 
 	isPre5_9 := m.isKernelPre5_9()
-	for i := range subMaps {
+	for i, subMap := range subMaps {
 		// if the subMap is empty we skip it
-		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
+		if len(subMap) == 0 {
 			continue
 		}
 
@@ -226,7 +226,7 @@ func (m *Manager) generateBPFMaps(policyID uint64, values []string) error {
 			policyID,
 			i,
 			isPre5_9,
-			subMaps[i], //nolint:gosec // false positive
+			subMap,
 		); err != nil {
 			return err
 		}
@@ -250,8 +250,8 @@ func (m *Manager) replaceBPFMaps(policyID uint64, values []string) error {
 	}
 
 	isPre5_9 := m.isKernelPre5_9()
-	for i := range subMaps {
-		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
+	for i, subMap := range subMaps {
+		if len(subMap) == 0 {
 			// No values for this size bucket - delete the old inner map if it exists
 			if err = m.policyStringMaps[i].Delete(policyID); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 				return fmt.Errorf("failed to remove policy (id=%d) from map %s: %w",
@@ -261,7 +261,7 @@ func (m *Manager) replaceBPFMaps(policyID uint64, values []string) error {
 		}
 
 		// Create and populate new inner map, then atomically replace
-		if err = m.replaceInnerBPFMap(policyID, i, isPre5_9, subMaps[i]); err != nil { //nolint:gosec // false positive
+		if err = m.replaceInnerBPFMap(policyID, i, isPre5_9, subMap); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR fixed the following linter check warning
```
internal/cgroups/cgroup_info.go:141:17: G115: integer overflow conversion int -> uint32 (gosec)
			return uint32(i), nil
			             ^
internal/bpf/policy_values.go:221:29: directive `//nolint:gosec // false positive` is unused for linter "gosec" (nolintlint)
		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
		                          ^
internal/bpf/policy_values.go:229:16: directive `//nolint:gosec // false positive` is unused for linter "gosec" (nolintlint)
			subMaps[i], //nolint:gosec // false positive
			            ^
internal/bpf/policy_values.go:254:29: directive `//nolint:gosec // false positive` is unused for linter "gosec" (nolintlint)
		if len(subMaps[i]) == 0 { //nolint:gosec // false positive
		                          ^
internal/bpf/policy_values.go:264:82: directive `//nolint:gosec // false positive` is unused for linter "gosec" (nolintlint)
		if err = m.replaceInnerBPFMap(policyID, i, isPre5_9, subMaps[i]); err != nil { //nolint:gosec // false positive
		                                                                               ^
internal/cgroups/cgroup_info.go:90:2: directive `//nolint:gosec // path is always set internally by us not by the user.` is unused for linter "gosec" (nolintlint)
	//nolint:gosec // path is always set internally by us not by the user.
	^
6 issues:
* gosec: 1
* nolintlint: 5
```

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
