### PR TITLE
fix: run agent with unconfined apparmor profile

### DIFF
--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -91,6 +91,15 @@
                 "podSecurityContext": {
                     "type": "object",
                     "properties": {
+                        "appArmorProfile": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "runAsNonRoot": {
                             "type": "boolean"
                         },

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -112,6 +112,9 @@ agent:
     runAsNonRoot: false
     seccompProfile:
       type: RuntimeDefault
+    # this is required for us the access the cgroup setting on the host
+    appArmorProfile:
+      type: Unconfined
   serviceAccount:
     # agent.serviceAccount.annotations -- Additional annotations to add to agent's service account.
     # @schema additionalProperties:true


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Run agent with unconfined apparmor profile.  This helps to support runtime-enforcer on GKE.

**Which issue(s) this PR fixes**

fixes #181 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
