### PR TITLE
chore: fix tilt debugger setup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -138,6 +138,7 @@ local_resource(
         "internal",
         "proto",
     ],
+    ignore = exclusions,
 )
 
 entrypoint = ["/debugger"]


### PR DESCRIPTION
**What this PR does / why we need it**:

The debugger depends on the EBPF build, so we need to exclude auto-generated files to avoid infinite loops during tilt setup

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
