### PR TITLE
feat: add short names and category

### DIFF
--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -146,6 +146,7 @@ func (s *WorkloadPolicyStatus) AddTransitioningNode(nodeName string) {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
+// +kubebuilder:resource:categories={rancher-security},singular="workloadpolicy",path="workloadpolicies",scope="Namespaced",shortName={wp}
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -25,6 +25,7 @@ type WorkloadPolicyProposalSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:categories={rancher-security},singular="workloadpolicyproposal",path="workloadpolicyproposals",scope="Namespaced",shortName={wpp}
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
@@ -9,9 +9,13 @@ metadata:
 spec:
   group: security.rancher.io
   names:
+    categories:
+    - rancher-security
     kind: WorkloadPolicy
     listKind: WorkloadPolicyList
     plural: workloadpolicies
+    shortNames:
+    - wp
     singular: workloadpolicy
   scope: Namespaced
   versions:

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicyproposals.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicyproposals.yaml
@@ -9,9 +9,13 @@ metadata:
 spec:
   group: security.rancher.io
   names:
+    categories:
+    - rancher-security
     kind: WorkloadPolicyProposal
     listKind: WorkloadPolicyProposalList
     plural: workloadpolicyproposals
+    shortNames:
+    - wpp
     singular: workloadpolicyproposal
   scope: Namespaced
   versions:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds short names to our resources and introduces the `rancher-security` category. 

### category

```bash
kubectl get rancher-security -A #to get all the resources under rancher-security category
NAMESPACE     NAME                                                       AGE
kube-system   workloadpolicyproposal.security.rancher.io/ds-kindnet      21s
kube-system   workloadpolicyproposal.security.rancher.io/ds-kube-proxy   20s
```
I chose `rancher-security` so that we can also add other resources in the future, for example, network policies or other things. We can also use something more specific, like `runtime-enforcer` as a category...

### short names
```bash
kubectl get wp
kubectl get wpp
```


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
