### PR TITLE
doc(plugin): how to enable auto-complete

### DIFF
--- a/cmd/kubectl-plugin/README.md
+++ b/cmd/kubectl-plugin/README.md
@@ -16,7 +16,7 @@ are attached to every [GitHub Release](../../releases).
 
 ```bash
 # Example: linux/amd64
-VERSION=v0.1.0
+VERSION=v0.4.0
 curl -Lo kubectl-runtime_enforcer \
   "https://github.com/rancher-sandbox/runtime-enforcer/releases/download/${VERSION}/kubectl-runtime_enforcer-linux-amd64"
 chmod +x kubectl-runtime_enforcer
@@ -27,6 +27,20 @@ Verify the download with the accompanying `.sha256` file:
 
 ```bash
 sha256sum --check kubectl-runtime_enforcer-linux-amd64.sha256
+```
+
+### Enable auto-completion
+
+To enable auto-completion, make sure that you enable the auto-completion of kubectl.
+Then, create a script called `kubectl_complete-runtime_enforcer` following the below steps:
+
+```bash
+cat <<EOF > kubectl_complete-runtime_enforcer
+#!/bin/bash
+kubectl runtime-enforcer __complete "\$@"
+EOF
+chmod +x kubectl_complete-runtime_enforcer
+sudo mv kubectl_complete-runtime_enforcer /usr/local/bin/
 ```
 
 ### Build from source


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Today, while we can use `kubectl-runtime_enforcer complete` to generate auto-completion script when we run the binary directly, the autocomplete feature is actually is broken in `kubectl runtime-enforcer` scenario.  This is because cobra doesn't allow us to change the executable name to `kubectl runtime-enforcer` instead of `kubectl-runtime_enforcer`, so it's never able to find the correct executable to run when we run `kubectl runtime-enforcer <tab>`.

Alternatively, [k8s 1.26](https://github.com/kubernetes/kubernetes/pull/105867) allows kubectl plugin's autocomplete to be done via a separate executable, `kubectl_complete-<plugin-name>`.  This can be done via cobra's `kubectl runtime-enforcer __complete`, so no code change is required this.  

This PR is to add document about how to use it.   The version of kubectl plugin is also updated in the doc, so it won't be a dead link.  

Note: krew doesn't support deploying this via `kubectl krew install` yet, but it doesn't block us from adding documents about how to use this.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
