### PR TITLE
feat: add/remove executables to the allowlist of an existing policy

### DIFF
--- a/cmd/kubectl-plugin/policy.go
+++ b/cmd/kubectl-plugin/policy.go
@@ -13,6 +13,8 @@ func newPolicyCmd() *cobra.Command {
 	cmd.AddCommand(newPolicyModeProtectCmd())
 	cmd.AddCommand(newPolicyModeMonitorCmd())
 	cmd.AddCommand(newPolicyShowCmd())
+	cmd.AddCommand(newPolicyExecAllowCmd())
+	cmd.AddCommand(newPolicyExecDenyCmd())
 
 	return cmd
 }

--- a/cmd/kubectl-plugin/policy_exec.go
+++ b/cmd/kubectl-plugin/policy_exec.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+
+	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type policyExecAction string
+
+const (
+	policyExecActionAllow policyExecAction = "allow"
+	policyExecActionDeny  policyExecAction = "deny"
+
+	minPolicyExecArgs = 3
+)
+
+type policyExecOptions struct {
+	commonOptions
+
+	PolicyName    string
+	ContainerName string
+	Executables   []string
+	Action        policyExecAction
+}
+
+func newPolicyExecCmd(action policyExecAction) *cobra.Command {
+	use := fmt.Sprintf("%s POLICY_NAME <container-name> <executable-name> [<executable-name>...]", action)
+	short := fmt.Sprintf("%s executables for a WorkloadPolicy container", action)
+
+	opts := &policyExecOptions{
+		commonOptions: newCommonOptions(),
+		Action:        action,
+	}
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.MinimumNArgs(minPolicyExecArgs),
+		RunE:  runPolicyExecCmd(opts),
+	}
+
+	cmd.SetUsageTemplate(subcommandUsageTemplate)
+
+	// Standard kube flags (adds --namespace, --kubeconfig, --context, etc.)
+	opts.configFlags.AddFlags(cmd.Flags())
+
+	// Plugin-specific flags
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would happen without making any changes")
+
+	return cmd
+}
+
+func newPolicyExecAllowCmd() *cobra.Command {
+	return newPolicyExecCmd(policyExecActionAllow)
+}
+
+func newPolicyExecDenyCmd() *cobra.Command {
+	return newPolicyExecCmd(policyExecActionDeny)
+}
+
+func runPolicyExecCmd(opts *policyExecOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		opts.PolicyName = args[0]
+		opts.ContainerName = args[1]
+		opts.Executables = args[2:]
+
+		return withRuntimeEnforcerClient(cmd, &opts.commonOptions, func(
+			ctx context.Context,
+			securityClient securityclient.SecurityV1alpha1Interface,
+		) error {
+			return runPolicyExec(ctx, securityClient, opts, opts.ioStreams.Out)
+		})
+	}
+}
+
+func runPolicyExec(
+	ctx context.Context,
+	client securityclient.SecurityV1alpha1Interface,
+	opts *policyExecOptions,
+	out io.Writer,
+) error {
+	policy, err := client.WorkloadPolicies(opts.Namespace).Get(ctx, opts.PolicyName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("workloadpolicy %q not found in namespace %q", opts.PolicyName, opts.Namespace)
+		}
+		return fmt.Errorf(
+			"failed to get WorkloadPolicy %q in namespace %q: %w",
+			opts.PolicyName,
+			opts.Namespace,
+			err,
+		)
+	}
+
+	changed, err := applyExecutablesToPolicy(policy.Spec.RulesByContainer, opts)
+	if err != nil {
+		return err
+	}
+
+	if !changed {
+		fmt.Fprintf(
+			out,
+			"No changes required for WorkloadPolicy %q in namespace %q.\n",
+			policy.Name,
+			policy.Namespace,
+		)
+		return nil
+	}
+
+	if opts.DryRun {
+		fmt.Fprintf(
+			out,
+			"Would %s executables for WorkloadPolicy %q in namespace %q.\n",
+			opts.Action,
+			policy.Name,
+			policy.Namespace,
+		)
+
+		rules := policy.Spec.RulesByContainer[opts.ContainerName]
+		fmt.Fprintf(
+			out,
+			"  Container %q final allowed executables: %v\n",
+			opts.ContainerName,
+			rules.Executables.Allowed,
+		)
+	}
+
+	if err = updateWorkloadPolicy(ctx, client, opts, policy); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(
+		out,
+		"Successfully updated executables for WorkloadPolicy %q in namespace %q.\n",
+		policy.Name,
+		policy.Namespace,
+	)
+
+	return nil
+}
+
+func applyExecutablesToPolicy(
+	rulesByContainer map[string]*apiv1alpha1.WorkloadPolicyRules,
+	opts *policyExecOptions,
+) (bool, error) {
+	if rulesByContainer == nil {
+		return false, fmt.Errorf("policy %q has no rules for containers", opts.PolicyName)
+	}
+
+	rules, ok := rulesByContainer[opts.ContainerName]
+	if !ok {
+		return false, fmt.Errorf("container %q not found in policy", opts.ContainerName)
+	}
+
+	if rules == nil {
+		rules = &apiv1alpha1.WorkloadPolicyRules{}
+		rulesByContainer[opts.ContainerName] = rules
+	}
+
+	var updated []string
+	var containerChanged bool
+	switch opts.Action {
+	case policyExecActionAllow:
+		updated, containerChanged = allowExecutables(rules.Executables.Allowed, opts.Executables)
+	case policyExecActionDeny:
+		updated, containerChanged = denyExecutables(rules.Executables.Allowed, opts.Executables)
+	default:
+		return false, fmt.Errorf("unsupported action %q", opts.Action)
+	}
+
+	if containerChanged {
+		rules.Executables.Allowed = updated
+	}
+
+	return containerChanged, nil
+}
+
+func allowExecutables(executables []string, allowed []string) ([]string, bool) {
+	changed := false
+
+	for _, exec := range allowed {
+		if !slices.Contains(executables, exec) {
+			executables = append(executables, exec)
+			changed = true
+		}
+	}
+
+	return executables, changed
+}
+
+func denyExecutables(executables []string, denied []string) ([]string, bool) {
+	if len(executables) == 0 {
+		return executables, false
+	}
+
+	newExecutables := make([]string, 0, len(executables))
+	changed := false
+
+	for _, exec := range executables {
+		if !slices.Contains(denied, exec) {
+			newExecutables = append(newExecutables, exec)
+		} else {
+			changed = true
+		}
+	}
+
+	return newExecutables, changed
+}
+
+func updateWorkloadPolicy(
+	ctx context.Context,
+	client securityclient.SecurityV1alpha1Interface,
+	opts *policyExecOptions,
+	policy *apiv1alpha1.WorkloadPolicy,
+) error {
+	updateOptions := metav1.UpdateOptions{}
+	if opts.DryRun {
+		updateOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	if _, err := client.WorkloadPolicies(opts.Namespace).
+		Update(ctx, policy, updateOptions); err != nil {
+		if apierrors.IsConflict(err) {
+			return fmt.Errorf(
+				"WorkloadPolicy %q in namespace %q was modified concurrently",
+				policy.Name,
+				policy.Namespace,
+			)
+		}
+		return fmt.Errorf(
+			"failed to update WorkloadPolicy %q in namespace %q: %w",
+			policy.Name,
+			policy.Namespace,
+			err,
+		)
+	}
+
+	return nil
+}

--- a/cmd/kubectl-plugin/policy_exec_test.go
+++ b/cmd/kubectl-plugin/policy_exec_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	fakeclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRunPolicyExec(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ns            = "test"
+		name          = "test-policy"
+		containerName = "app"
+	)
+
+	tests := []struct {
+		name         string
+		action       policyExecAction
+		dryRun       bool
+		initialList  []string
+		executables  []string
+		expectedList []string
+		expectMsgSub string
+	}{
+		{
+			name:         "allow_add_multiple",
+			action:       policyExecActionAllow,
+			dryRun:       false,
+			initialList:  []string{"/bin/ls"},
+			executables:  []string{"/bin/mv", "/bin/cat"},
+			expectedList: []string{"/bin/ls", "/bin/mv", "/bin/cat"},
+			expectMsgSub: "Successfully updated executables",
+		},
+		{
+			name:         "deny_remove_one",
+			action:       policyExecActionDeny,
+			dryRun:       false,
+			initialList:  []string{"/bin/ls", "/bin/mv", "/bin/cat"},
+			executables:  []string{"/bin/mv"},
+			expectedList: []string{"/bin/ls", "/bin/cat"},
+			expectMsgSub: "Successfully updated executables",
+		},
+		{
+			name:         "allow_dry_run",
+			action:       policyExecActionAllow,
+			dryRun:       true,
+			initialList:  []string{"/bin/ls"},
+			executables:  []string{"/bin/mv", "/bin/cat"},
+			expectedList: []string{"/bin/ls", "/bin/mv", "/bin/cat"},
+			expectMsgSub: "Would allow executables for WorkloadPolicy",
+		},
+		{
+			name:         "deny_dry_run",
+			action:       policyExecActionDeny,
+			dryRun:       true,
+			initialList:  []string{"/bin/ls", "/bin/mv", "/bin/cat"},
+			executables:  []string{"/bin/mv"},
+			expectedList: []string{"/bin/ls", "/bin/cat"},
+			expectMsgSub: "Would deny executables for WorkloadPolicy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := &apiv1alpha1.WorkloadPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+				Spec: apiv1alpha1.WorkloadPolicySpec{
+					RulesByContainer: map[string]*apiv1alpha1.WorkloadPolicyRules{
+						"app": {
+							Executables: apiv1alpha1.WorkloadPolicyExecutables{
+								Allowed: append([]string(nil), tt.initialList...),
+							},
+						},
+					},
+				},
+			}
+
+			clientset := fakeclient.NewClientset(policy)
+			securityClient := clientset.SecurityV1alpha1()
+
+			var out bytes.Buffer
+			opts := &policyExecOptions{
+				commonOptions: commonOptions{
+					Namespace: ns,
+					DryRun:    tt.dryRun,
+				},
+				PolicyName:    name,
+				ContainerName: containerName,
+				Executables:   tt.executables,
+				Action:        tt.action,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
+			defer cancel()
+
+			err := runPolicyExec(ctx, securityClient, opts, &out)
+			require.NoError(t, err)
+
+			output := out.String()
+			require.Contains(t, output, tt.expectMsgSub)
+
+			updatedPolicy, err := securityClient.WorkloadPolicies(ns).Get(ctx, name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			rules := updatedPolicy.Spec.RulesByContainer[containerName]
+			require.NotNil(t, rules)
+			require.ElementsMatch(t, tt.expectedList, rules.Executables.Allowed)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
The user can add an arbitrary executable to the allow list of a WorkloadPolicy
- `kubectl runtime-enforcer policy allow POLICY_NAME <executables>` — allow executables
- `kubectl runtime-enforcer policy deny POLICY_NAME  <executables>` — deny executables.

**Which issue(s) this PR fixes**

fixes #404 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
