### PR TITLE
fix: remove bpf dependency in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ TAG ?= latest
 
 define BUILD_template =
 .PHONY: build-$(1)-image
-build-$(1)-image:
+build-$(1)-image: generate-ebpf vet
 	docker buildx build -f package/Dockerfile.$(1) \
 	-t "$(REPO)/$(1):$(TAG)" --load .
 	@echo "Built $(REPO)/$(1):$(TAG)"
@@ -89,7 +89,7 @@ helm-unittest:
 	helm unittest charts/runtime-enforcer/ --file "tests/**/*_test.yaml"
 
 .PHONY: test-e2e
-test-e2e: generate-ebpf vet
+test-e2e:
 ifneq ($(E2E_USE_EXISTING_CLUSTER),true)
 ifeq ($(E2E_NO_REBUILD),)
 	TAG=latest make $(E2E_DEPS)

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/utils"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventscraper"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -16,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -32,36 +32,6 @@ import (
 // This is a arbitrary number right now and can be fine-tuned or made configurable in the future.
 // On a simple kind cluster we saw more than 4200 process exec during the initial process cache dump, so this seems a reasonable default for now.
 const DefaultEventChannelBufferSize = 4096
-
-// GetWorkloadPolicyProposalName returns the name of WorkloadPolicyProposal
-// based on a high level resource and its name.
-func GetWorkloadPolicyProposalName(kind string, resourceName string) (string, error) {
-	var shortname string
-	switch kind {
-	case "Deployment":
-		shortname = "deploy"
-	case "ReplicaSet":
-		shortname = "rs"
-	case "DaemonSet":
-		shortname = "ds"
-	case "CronJob":
-		shortname = "cronjob"
-	case "Job":
-		shortname = "job"
-	case "StatefulSet":
-		shortname = "sts"
-	default:
-		return "", fmt.Errorf("unknown kind: %s", kind)
-	}
-	ret := shortname + "-" + resourceName
-
-	// The max name length in k8s
-	if len(ret) > validation.DNS1123SubdomainMaxLength {
-		return "", fmt.Errorf("the name %s exceeds the maximum name length", ret)
-	}
-
-	return shortname + "-" + resourceName, nil
-}
 
 type LearningReconciler struct {
 	client.Client
@@ -147,7 +117,7 @@ func (r *LearningReconciler) Reconcile(
 		}
 	}
 
-	proposalName, err = GetWorkloadPolicyProposalName(req.WorkloadKind, req.Workload)
+	proposalName, err = utils.GetWorkloadPolicyProposalName(req.WorkloadKind, req.Workload)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get proposal name: %w", err)
 	}

--- a/internal/eventhandler/utils/utils.go
+++ b/internal/eventhandler/utils/utils.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GetWorkloadPolicyProposalName returns the name of WorkloadPolicyProposal
+// based on a high level resource and its name.
+func GetWorkloadPolicyProposalName(kind string, resourceName string) (string, error) {
+	var shortname string
+	switch kind {
+	case "Deployment":
+		shortname = "deploy"
+	case "ReplicaSet":
+		shortname = "rs"
+	case "DaemonSet":
+		shortname = "ds"
+	case "CronJob":
+		shortname = "cronjob"
+	case "Job":
+		shortname = "job"
+	case "StatefulSet":
+		shortname = "sts"
+	default:
+		return "", fmt.Errorf("unknown kind: %s", kind)
+	}
+	ret := shortname + "-" + resourceName
+
+	// The max name length in k8s
+	if len(ret) > validation.DNS1123SubdomainMaxLength {
+		return "", fmt.Errorf("the name %s exceeds the maximum name length", ret)
+	}
+
+	return shortname + "-" + resourceName, nil
+}

--- a/test/e2e/learning_mode_test.go
+++ b/test/e2e/learning_mode_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
-	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -113,7 +113,7 @@ func getLearningModeTest() types.Feature {
 					obj := tc.ParseFunc()
 					t.Log("verifying if a proposal resource can be created: ", kind)
 
-					proposalName, err := eventhandler.GetWorkloadPolicyProposalName(kind, obj.GetName())
+					proposalName, err := utils.GetWorkloadPolicyProposalName(kind, obj.GetName())
 					require.NoError(t, err)
 
 					proposal := v1alpha1.WorkloadPolicyProposal{
@@ -243,7 +243,7 @@ func getLearningModeNamespaceSelectorTest() types.Feature {
 		Assess("learning creates WorkloadPolicyProposal only in the labeled namespace", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 			r := ctx.Value(key("client")).(*resources.Resources)
 
-			proposalName, err := eventhandler.GetWorkloadPolicyProposalName("Deployment", deploymentName)
+			proposalName, err := utils.GetWorkloadPolicyProposalName("Deployment", deploymentName)
 			require.NoError(t, err)
 
 			t.Log("verifying proposal is created and learns in the learning-enabled namespace")


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Remove the dependency of bpf codes, so we can run e2e tests without the need to install libbpf and others if the latest images are used.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
