### PR TITLE
feat(manager): support ebpf batch operations where possible

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -78,6 +78,7 @@
         "kubelet",
         "kubepods",
         "besteffort",
+        "userspace",
         "gosec",
         "eventscraper",
         "libbpf",

--- a/internal/bpf/cgroup_policy.go
+++ b/internal/bpf/cgroup_policy.go
@@ -41,7 +41,13 @@ func addPolicyToCgroups(cgToPol *ebpf.Map, targetPolID uint64, cgroupIDs []uint6
 	}
 
 	for _, cgID := range cgroupIDs {
-		// todo!: check if we can use batch operations and when they are supported
+		// Here we cannot use `BatchUpdate` because we want to detect overlapping policies.
+		// https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/syscall.c#L1955
+		// - `ElemFlag` can only be `BPF_F_LOCK` if the map is behind a spinLock. Otherwise we use 0.
+		//    so we call `bpf_map_update_value` https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/syscall.c#L1989
+		//    with 0 that is equivalent to `BPF_ANY`.
+		// - `Flag` is not used in batch operations.
+		// Since we can only use `BPF_ANY`, we cannot check for overlapping policies.
 		err := cgToPol.Update(&cgID, &targetPolID, ebpf.UpdateNoExist)
 		if err == nil {
 			continue
@@ -73,7 +79,7 @@ func removePolicyFromCgroups(cgToPol *ebpf.Map, targetPolID uint64) error {
 	var polID uint64
 	cgIDList := []uint64{}
 
-	// Fiest we iterate to find all the cgroup ids associated with the target policy
+	// First we iterate to find all the cgroup ids associated with the target policy
 	iter := cgToPol.Iterate()
 	for iter.Next(&cgID, &polID) {
 		if targetPolID == polID {
@@ -85,18 +91,20 @@ func removePolicyFromCgroups(cgToPol *ebpf.Map, targetPolID uint64) error {
 		return fmt.Errorf("failed to iterate cgroup to policy map: %w", err)
 	}
 
-	// Now we remove all the cgroup ids associated with the target policy
-	var multiErr error
-	for _, cgID := range cgIDList {
-		// Here all the keys should exist, so we report any error
-		if err := cgToPol.Delete(&cgID); err != nil {
-			multiErr = errors.Join(
-				multiErr,
-				fmt.Errorf("failed to remove cgroup %d from policy map: %w", cgID, err),
-			)
-		}
+	if len(cgIDList) == 0 {
+		// Nothing to remove
+		return nil
 	}
-	return multiErr
+
+	// Now we remove all the cgroup ids associated with the target policy
+	// In this case it's fine to use a batch operation since we already checked for existence
+	// and nobody will touch the cgroup map while we are working on it.
+	// The userspace is the only one that modify the map and here we are under lock.
+	count, err := cgToPol.BatchDelete(cgIDList, nil)
+	if err != nil || count != len(cgIDList) {
+		return fmt.Errorf("failed to remove cgroups %v from policy map: %w", cgIDList, err)
+	}
+	return nil
 }
 
 func removeCgroups(cgToPol *ebpf.Map, targetPolID uint64, cgroupIDs []uint64) error {
@@ -106,8 +114,8 @@ func removeCgroups(cgToPol *ebpf.Map, targetPolID uint64, cgroupIDs []uint64) er
 
 	var multiErr error
 	for _, cgID := range cgroupIDs {
-		// todo!: check if we can use batch operations
-		// it is possible that we call the remove just to cleanup so we ignore the ErrKeyNotExist error.
+		// We cannot use `BatchDelete` because it will fail if at least one key doesn't exist.
+		// This method is always called on containers deletion even if they were not associated with a policy so it's likely we will face some ErrKeyNotExist.
 		if err := cgToPol.Delete(&cgID); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
 			multiErr = errors.Join(
 				multiErr,

--- a/internal/bpf/cgroup_policy_test.go
+++ b/internal/bpf/cgroup_policy_test.go
@@ -1,0 +1,190 @@
+package bpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/require"
+)
+
+func dumpMap(m *ebpf.Map) map[uint64]uint64 {
+	iter := m.Iterate()
+	dump := make(map[uint64]uint64)
+	var key, value uint64
+	for iter.Next(&key, &value) {
+		dump[key] = value
+	}
+	return dump
+}
+
+func TestCgroupMapOperations(t *testing.T) {
+	cgToPol, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    8, // cgroupID
+		ValueSize:  8, // policyID
+		MaxEntries: 100,
+	})
+	require.NoError(t, err, "Failed to create test map")
+
+	policy1 := uint64(1)
+	policy2 := uint64(2)
+	cgroup1 := uint64(1)
+	cgroup2 := uint64(2)
+	cgroup3 := uint64(3)
+	cgroupKeys := []uint64{cgroup1, cgroup2, cgroup3}
+	expectedMap := map[uint64]uint64{
+		cgroup1: policy1,
+		cgroup2: policy1,
+		cgroup3: policy1,
+	}
+
+	////////////////////////
+	// addPolicyToCgroups
+	///////////////////////
+
+	// We cannot use policy 0 to update cgroups
+	require.Error(t, addPolicyToCgroups(cgToPol, 0, cgroupKeys))
+
+	// We add policy to cgroups
+	require.NoError(t, addPolicyToCgroups(cgToPol, policy1, cgroupKeys))
+	require.Equal(t, expectedMap, dumpMap(cgToPol))
+
+	// we try again the same operation, nothing should change.
+	require.NoError(t, addPolicyToCgroups(cgToPol, policy1, cgroupKeys))
+	require.Equal(t, expectedMap, dumpMap(cgToPol))
+
+	// if we now try to bind a new policy it should fail, because cgroups are already associated.
+	require.Error(t, addPolicyToCgroups(cgToPol, policy2, []uint64{cgroup2}))
+	// Nothing should change.
+	require.Equal(t, expectedMap, dumpMap(cgToPol))
+
+	////////////////////////
+	// removeCgroups
+	///////////////////////
+
+	// If we call with a policy != 0 we expect an error
+	require.Error(t, removeCgroups(cgToPol, policy1, []uint64{cgroup1}))
+
+	// Now we remove the cgroup1
+	require.NoError(t, removeCgroups(cgToPol, 0, []uint64{cgroup1}))
+
+	newExpectedMap := map[uint64]uint64{
+		cgroup2: policy1,
+		cgroup3: policy1,
+	}
+	require.Equal(t, newExpectedMap, dumpMap(cgToPol))
+
+	// If we do the operation again nothing should change
+	require.NoError(t, removeCgroups(cgToPol, 0, []uint64{cgroup1}))
+	require.Equal(t, newExpectedMap, dumpMap(cgToPol))
+
+	////////////////////////
+	// removePolicyFromCgroups
+	///////////////////////
+
+	// There are no cgroups associated with policy2, so nothing should change
+	require.NoError(t, removePolicyFromCgroups(cgToPol, policy2))
+	require.Equal(t, newExpectedMap, dumpMap(cgToPol))
+
+	// This time we remove all cgroups associated with policy1
+	require.NoError(t, removePolicyFromCgroups(cgToPol, policy1))
+	require.Empty(t, dumpMap(cgToPol))
+}
+
+// TestBatchOperations tests the batch operations of the cilium ebpf library not our code.
+// This is a reminder on how to use batch operations.
+func TestBatchOperations(t *testing.T) {
+	cgToPol, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    8, // cgroupID
+		ValueSize:  8, // policyID
+		MaxEntries: 100,
+	})
+	require.NoError(t, err, "Failed to create test map")
+
+	policy1 := uint64(1)
+	cgroup1 := uint64(1)
+	cgroup2 := uint64(2)
+	cgroup3 := uint64(3)
+	cgroupSet := []uint64{cgroup1, cgroup2, cgroup3}
+	values := make([]uint64, len(cgroupSet))
+	for i := range cgroupSet {
+		values[i] = policy1
+	}
+
+	initial := dumpMap(cgToPol)
+	require.Empty(t, initial, "Map should be empty at the beginning")
+
+	///////////////////////
+	// First batch Update
+	///////////////////////
+
+	count, err := cgToPol.BatchUpdate(cgroupSet, values, &ebpf.BatchOptions{
+		Flags: uint64(ebpf.UpdateAny),
+	})
+	require.NoError(t, err, "Batch update failed")
+	require.Equal(t, len(cgroupSet), count, "Batch update did not update all entries")
+	require.Equal(t, map[uint64]uint64{
+		cgroup1: policy1,
+		cgroup2: policy1,
+		cgroup3: policy1,
+	}, dumpMap(cgToPol))
+
+	///////////////////////
+	// Try UpdateNoExist
+	///////////////////////
+
+	// https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/syscall.c#L1955
+	// - `ElemFlag` can only be `BPF_F_LOCK` if the map is behind a spinLock -> We provide 0 so we call `bpf_map_update_value`
+	//    https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/syscall.c#L1989 with 0
+	//    that is equivalent to `BPF_ANY`.
+	// - `Flag` is not used in batch operations.
+	values[0] = uint64(23)
+	values[1] = uint64(24)
+	values[2] = uint64(25)
+	count, err = cgToPol.BatchUpdate(cgroupSet, values, &ebpf.BatchOptions{
+		Flags: uint64(ebpf.UpdateNoExist),
+	})
+	require.NoError(t, err, "Batch update failed")
+	require.Equal(t, len(cgroupSet), count, "Batch update did not update all entries")
+	// even if we used UpdateNoExist, the map contains the new values
+	require.Equal(t, map[uint64]uint64{
+		cgroup1: uint64(23),
+		cgroup2: uint64(24),
+		cgroup3: uint64(25),
+	}, dumpMap(cgToPol))
+
+	///////////////////////
+	// Lookup batch
+	///////////////////////
+
+	var cursor ebpf.MapBatchCursor
+	lookupKeys := []uint64{cgroup1, cgroup3}
+	lookupValues := make([]uint64, len(lookupKeys))
+	// iterate over the buckets doesn't get the values associated with the keys.
+	// https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/hashtab.c#L1677
+	count, err = cgToPol.BatchLookup(&cursor, lookupKeys, lookupValues, nil)
+	require.NoError(t, err, "Batch lookup failed")
+	require.Equal(t, len(lookupKeys), count, "Batch lookup did not find all entries")
+
+	// We cannot assert the values directly since the iteration order is not guaranteed.
+	//
+	// require.Equal(t, lookupValues, []uint64{
+	// 	uint64(23),
+	// 	uint64(25),
+	// }, "Batch lookup did not return expected values")
+
+	///////////////////////
+	// Delete batch on all elements
+	///////////////////////
+
+	// Also here flags are ignored https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/syscall.c#L1889
+	count, err = cgToPol.BatchDelete(cgroupSet, nil)
+	require.NoError(t, err, "Batch delete failed")
+	require.Equal(t, len(cgroupSet), count, "Batch delete did not delete all entries")
+
+	// Retry it but this time cgroups do not exist anymore so we expect ErrKeyNotExist
+	_, err = cgToPol.BatchDelete(cgroupSet, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ebpf.ErrKeyNotExist)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The behavior of batch operations is not well-documented, so I looked into the kernel code a little bit.
I saved my findings in a unit test `TestBatchOperations`, where I try to explain the usage of these operations.
The result is that in most of the cases we cannot use them because their behavior is too restrictive.

Batch operations are supported since kernel 5.6, so we shouldn't have issues https://github.com/torvalds/linux/commit/aa2e93b8e58e18442edfb2427446732415bc215e


**Which issue(s) this PR fixes**

fixes #109 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
