### PR TITLE
feat: remove requeue, pod deletion will trigger a reconcile

### DIFF
--- a/internal/controller/workloadpolicy_controller.go
+++ b/internal/controller/workloadpolicy_controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -19,10 +18,6 @@ import (
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-const (
-	PolicyDeletionRequeueDelay = 90 * time.Second
 )
 
 // WorkloadPolicyReconciler reconciles a WorkloadPolicy object.
@@ -85,11 +80,11 @@ func (r *WorkloadPolicyReconciler) handleDeletion(
 		}
 
 		if len(podList.Items) > 0 {
-			logger.Info("Cannot remove finalizer: policy still in use by pods",
+			logger.V(1).Info("Cannot remove finalizer: policy still in use by pods",
 				"policy", policy.Name,
 				"podCount", len(podList.Items))
-			// Requeue to check again later
-			return ctrl.Result{RequeueAfter: PolicyDeletionRequeueDelay}, nil
+			// Pod deletion will trigger a reconcile, and we'll retry finalizer removal then.
+			return ctrl.Result{}, nil
 		}
 
 		// No pods using this policy, safe to remove finalizer


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
When a WorkloadPolicy is deleted while it is still in use by a Pod, a requeue log is emitted every 90 seconds, which is too frequent. This PR removes the requeue. So the behaviour will be the pod deletion will trigger a reconcile, and it'll retry finalizer removal then removes the policy.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
