### PR TITLE
feat: delete wpp and stop learning when it is promoted to wp

### DIFF
--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -11,6 +11,12 @@ const (
 	// they are not deleted while still in use by Pods.
 	WorkloadPolicyFinalizer = "workloadpolicy.security.rancher.io/finalizer"
 
+	// PromotedFromLabelKey is set on a WorkloadPolicy when it is created by
+	// promoting a WorkloadPolicyProposal.
+	// The learning controller uses it to avoid recreating proposals for
+	// workloads that are already protected by an existing policy.
+	PromotedFromLabelKey = "workloadpolicy.security.rancher.io/promoted-from"
+
 	// MaxNodesWithIssues is the maximum number of nodes with issues to report.
 	// we don't want to overwhelm the user with too much information.
 	MaxNodesWithIssues = 20

--- a/docs/phases.adoc
+++ b/docs/phases.adoc
@@ -27,8 +27,10 @@ Operationally, if you want complete proposals, enable learning first and then *(
 ** No per-workload configuration is required to start generating proposals (proposals are created as exec events are observed).
 * *Leave*
 ** Mark the corresponding proposal as ready by setting the label: `security.rancher.io/policy-ready=true`
-** This triggers creation of a `WorkloadPolicy` (defaulting to `mode: monitor`).
-** The `WorkloadPolicyProposal` is *not* automatically removed; instead, it is no longer updated with newly observed processes.
+** This triggers creation of a `WorkloadPolicy` (defaulting to `mode: monitor`), with the `workloadpolicy.security.rancher.io/promoted-from` label set so the promotion relationship is explicit.
+** The `WorkloadPolicyProposal` object will be deleted after the promotion. Under rare conditions, caches might not be immediately updated, causing the `WorkloadPolicyProposal` to be created again. In those cases, a periodic cleanup will remove the leftover proposals.
+
+NOTE: If you create a `WorkloadPolicy` manually without that promotion relationship (no `security.rancher.io/policy-ready` label created in `WorkloadPolicyProposal`), the proposal is *not* removed by that flow. You must delete the `WorkloadPolicyProposal` manually.
 
 === CRDs created/updated during this phase
 

--- a/internal/controller/workloadpolicyproposal_controller.go
+++ b/internal/controller/workloadpolicyproposal_controller.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/proposalutils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,6 +46,28 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
+	// After a proposal is promoted and deleted, an agent can recreate a WorkloadPolicyProposal
+	// at the same time. If a WorkloadPolicy already exists with promoted-from=<proposalName>,
+	// treat the proposal as leftover and delete it. This is eventually reconciled on the controller-runtime
+	// resync (SyncPeriod, 10 hours by default) if both the proposal and the policy are still in the cluster.
+	var alreadyPromoted bool
+	alreadyPromoted, err = proposalutils.HasProposalBeenPromoted(
+		ctx, r.Client,
+		policyProposal.Namespace,
+		policyProposal.Name,
+	)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to check promoted WorkloadPolicy: %w", err)
+	}
+	if alreadyPromoted {
+		log.Info("Deleting WorkloadPolicyProposal; promoted WorkloadPolicy already exists",
+			"proposal", policyProposal.Name)
+		if err = r.Delete(ctx, &policyProposal); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, nil
+	}
+
 	labels := policyProposal.GetLabels()
 	approved := labels[securityv1alpha1.ApprovalLabelKey] == "true"
 
@@ -56,15 +79,25 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      policyProposal.ObjectMeta.Name,
 			Namespace: policyProposal.ObjectMeta.Namespace,
+			Labels: map[string]string{
+				securityv1alpha1.PromotedFromLabelKey: policyProposal.Name,
+			},
 		},
+		Spec: policyProposal.Spec.IntoWorkloadPolicySpec(),
 	}
 
-	_, err = controllerutil.CreateOrPatch(ctx, r.Client, &policy, func() error {
-		policy.Spec = policyProposal.Spec.IntoWorkloadPolicySpec()
-		return nil
-	})
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to call CreateOrPatch: %w", err)
+	if err = r.Create(ctx, &policy); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			log.Info("WorkloadPolicy already exists, skipping creation", "policy", policy.NamespacedName())
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("failed to create WorkloadPolicy: %w", err)
+	}
+
+	// Once we successfully promote the proposal into a policy, we no longer
+	// need the proposal to remain in the cluster.
+	if err = r.Delete(ctx, &policyProposal); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -126,6 +126,65 @@ func (r *LearningReconciler) handleAdmissionError(logger logr.Logger, err error)
 // kubebuilder annotations for accessing policy proposals and namespaces.
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security.rancher.io,resources=workloadpolicyproposals,verbs=create;get;list;watch;update;patch
+// +kubebuilder:rbac:groups=security.rancher.io,resources=workloadpolicies,verbs=list;watch
+
+// skipOrLearn decides whether to skip learning.
+//
+// Skip (true, nil) when:
+//   - req.PolicyName is set (pod already has security.rancher.io/policy).
+//   - the proposal does not exist but a WorkloadPolicy with workloadpolicy.security.rancher.io/promoted-from=<proposalName> exists.
+//
+// Learn (false, nil) when:
+//   - the proposal exists (no security.rancher.io/policy label set on the proposal).
+//   - the proposal does not exist but no WorkloadPolicy with workloadpolicy.security.rancher.io/promoted-from=<proposalName> exists.
+func (r *LearningReconciler) skipOrLearn(
+	ctx context.Context,
+	req eventscraper.KubeProcessInfo,
+	proposalName string,
+	policyProposal *securityv1alpha1.WorkloadPolicyProposal,
+) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	if req.PolicyName != "" {
+		logger.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+			"Ignoring learning event because pod is already bound to a WorkloadPolicy",
+			"workload", req.Workload,
+			"workload_kind", req.WorkloadKind,
+			"policy", req.PolicyName,
+		)
+		return true, nil
+	}
+
+	err := r.Client.Get(ctx, types.NamespacedName{
+		Namespace: req.Namespace,
+		Name:      proposalName,
+	}, policyProposal)
+	if err == nil {
+		return false, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to get WorkloadPolicyProposal before learning update: %w", err)
+	}
+
+	alreadyPromoted, err := proposalutils.HasProposalBeenPromoted(
+		ctx, r.Client, req.Namespace, proposalName,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if alreadyPromoted {
+		logger.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+			"Ignoring learning event because workload already has a promoted WorkloadPolicy",
+			"workload", req.Workload,
+			"workload_kind", req.WorkloadKind,
+			"proposal", proposalName,
+		)
+		return true, nil
+	}
+
+	return false, nil
+}
 
 // Reconcile maintains a retry mechanism with exponential backoff when processing learning events.
 func (r *LearningReconciler) Reconcile(
@@ -217,6 +276,11 @@ func (r *LearningReconciler) reconcile(
 			Name:      proposalName,
 			Namespace: req.Namespace,
 		},
+	}
+
+	skip, err := r.skipOrLearn(ctx, req, proposalName, policyProposal)
+	if err != nil || skip {
+		return ctrl.Result{}, err
 	}
 
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {

--- a/internal/eventhandler/learning_controller_test.go
+++ b/internal/eventhandler/learning_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventscraper"
 	"golang.org/x/sync/errgroup"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -351,6 +352,68 @@ var _ = Describe("Learning", func() {
 						Namespace: testProposal.Namespace,
 					},
 				})).To(Succeed())
+			})
+
+			It("should not learn process behavior when a WorkloadPolicy already exists", func() {
+				const testNamespace = "default"
+				const testResourceName = "ubuntu-deployment-4"
+				const testProposalName = "deploy-ubuntu-deployment-4"
+
+				processEvents := []eventscraper.KubeProcessInfo{
+					{
+						Namespace:      testNamespace,
+						Workload:       testResourceName,
+						WorkloadKind:   "Deployment",
+						ContainerName:  "ubuntu",
+						ExecutablePath: "/usr/bin/sleep",
+					},
+					{
+						Namespace:      testNamespace,
+						Workload:       testResourceName,
+						WorkloadKind:   "Deployment",
+						ContainerName:  "ubuntu",
+						ExecutablePath: "/usr/bin/ls",
+					},
+				}
+
+				reconciler := eventhandler.NewLearningReconciler(k8sClient, nil)
+
+				workloadPolicy := &securityv1alpha1.WorkloadPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testProposalName,
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							securityv1alpha1.PromotedFromLabelKey: testProposalName,
+						},
+					},
+					Spec: securityv1alpha1.WorkloadPolicySpec{
+						Mode: "monitor",
+					},
+				}
+				Expect(k8sClient.Create(ctx, workloadPolicy)).To(Succeed())
+
+				for _, learningEvent := range processEvents {
+					var result ctrl.Result
+					var err error
+					result, err = reconciler.Reconcile(ctx, learningEvent)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(ctrl.Result{}))
+				}
+
+				// The learning reconciler should not recreate the proposal while the policy exists.
+				proposalResult := &securityv1alpha1.WorkloadPolicyProposal{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testProposalName,
+						Namespace: testNamespace,
+					},
+				}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testProposalName,
+				}, proposalResult)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+
+				Expect(k8sClient.Delete(ctx, workloadPolicy)).To(Succeed())
 			})
 		})
 

--- a/internal/eventhandler/proposalutils/proposalutils.go
+++ b/internal/eventhandler/proposalutils/proposalutils.go
@@ -1,10 +1,13 @@
 package proposalutils
 
 import (
+	"context"
 	"fmt"
 
+	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/workloadkind"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func getKindShortName(kind string) (string, error) {
@@ -48,4 +51,26 @@ func GetWorkloadPolicyProposalName(kind string, resourceName string) (string, er
 	}
 
 	return shortname + "-" + resourceName, nil
+}
+
+func HasProposalBeenPromoted(
+	ctx context.Context,
+	c client.Client,
+	namespace, proposalName string,
+) (bool, error) {
+	var workloadPolicies securityv1alpha1.WorkloadPolicyList
+	if err := c.List(ctx, &workloadPolicies,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			securityv1alpha1.PromotedFromLabelKey: proposalName,
+		},
+	); err != nil {
+		return false, fmt.Errorf("failed to list WorkloadPolicies with promoted-from label: %w", err)
+	}
+
+	if len(workloadPolicies.Items) > 0 {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/internal/eventhandler/proposalutils/proposalutils_test.go
+++ b/internal/eventhandler/proposalutils/proposalutils_test.go
@@ -1,11 +1,16 @@
 package proposalutils_test
 
 import (
+	"context"
 	"testing"
 
+	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/proposalutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetWorkloadPolicyProposalName(t *testing.T) {
@@ -62,6 +67,65 @@ func TestGetWorkloadPolicyProposalName(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHasProposalBeenPromoted(t *testing.T) {
+	const (
+		defaultNamespace = "default"
+		proposalName     = "ubuntu-deployment"
+	)
+
+	tests := []struct {
+		name           string
+		existingPolicy *securityv1alpha1.WorkloadPolicy
+		namespace      string
+		proposalName   string
+		wantPromoted   bool
+	}{
+		{
+			name:         "returns false when no promoted WorkloadPolicy exists",
+			namespace:    defaultNamespace,
+			proposalName: proposalName,
+			wantPromoted: false,
+		},
+		{
+			name:         "returns true when promoted WorkloadPolicy exists",
+			namespace:    defaultNamespace,
+			proposalName: proposalName,
+			existingPolicy: &securityv1alpha1.WorkloadPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: defaultNamespace,
+					Name:      proposalName,
+					Labels: map[string]string{
+						securityv1alpha1.PromotedFromLabelKey: proposalName,
+					},
+				},
+			},
+			wantPromoted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, securityv1alpha1.AddToScheme(scheme))
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.existingPolicy != nil {
+				builder = builder.WithObjects(tt.existingPolicy)
+			}
+			cl := builder.Build()
+
+			promoted, err := proposalutils.HasProposalBeenPromoted(
+				context.Background(),
+				cl,
+				tt.namespace,
+				tt.proposalName,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPromoted, promoted)
 		})
 	}
 }

--- a/test/e2e/promotion_test.go
+++ b/test/e2e/promotion_test.go
@@ -131,6 +131,13 @@ func getPromotionTest() types.Feature {
 				}), wait.WithTimeout(defaultOperationTimeout))
 				require.NoError(t, err)
 
+				t.Log("waiting for the WorkloadPolicyProposal to be deleted: ", proposal.Name)
+				err = wait.For(
+					conditions.New(r).ResourceDeleted(proposal),
+					wait.WithTimeout(defaultOperationTimeout),
+				)
+				require.NoError(t, err)
+
 				return context.WithValue(ctx, key("policy"), &policy)
 			}).
 		Assess("pod exec will not be blocked since the policy is in monitoring mode",
@@ -144,12 +151,8 @@ func getPromotionTest() types.Feature {
 		Assess("delete policy", func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 			r := getClient(ctx)
 			policy := ctx.Value(key("policy")).(*v1alpha1.WorkloadPolicy)
-			proposal := ctx.Value(key("proposal")).(*v1alpha1.WorkloadPolicyProposal)
 
-			err := r.Delete(ctx, proposal)
-			require.NoError(t, err)
-
-			err = r.Delete(ctx, policy)
+			err := r.Delete(ctx, policy)
 			require.NoError(t, err)
 
 			return ctx


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Delete WorkloadPolicyProposal and stop learning behaviour after successful promotion to WorkloadPolicy

**Which issue(s) this PR fixes**

fixes #417 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
