### PR TITLE
test(e2e): adjust timeouts

### DIFF
--- a/internal/grpcexporter/agent_client.go
+++ b/internal/grpcexporter/agent_client.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	agentClientTimeout = 5 * time.Second
+	agentClientTimeout = 30 * time.Second
 )
 
 // AgentClientAPI this interface could be used to mock clients in tests.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -42,7 +42,7 @@ func waitForWorkloadPolicyStatusToBeUpdated(
 			return false
 		}
 		return true
-	}), wait.WithTimeout(15*time.Second))
+	}), wait.WithTimeout(60*time.Second))
 	require.NoError(t, err, "workloadpolicy status should be updated to Deployed")
 }
 

--- a/test/e2e/policy_per_container_test.go
+++ b/test/e2e/policy_per_container_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func getPolicyPerContainerTest() types.Feature {
-	workloadNamespace := envconf.RandomName("policy-per-container-namespace", 32)
+	workloadNamespace := envconf.RandomName("policy-per-container-ns", 32)
 	policyName := "per-container-policy"
 	podNameAllowed := "test-pod-allowed-init-main"
 	podNameBlocked := "test-pod-blocked-init-main"


### PR DESCRIPTION
Update a few timeouts to make e2e test reliable on RKE2.

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

E2E test is failing on RKE2.  This PR adjusts a few timeouts to make it more stable. 

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
