### PR TITLE
style: introduce constant for log verbosity

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher-sandbox/runtime-enforcer/internal/grpcexporter"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/nri"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/resolver"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/loglevel"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/workloadpolicyhandler"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -149,8 +150,8 @@ func waitForMutatingAdmissionWebhook(ctx context.Context) error {
 		retry.OnRetry(func(n uint, err error) {
 			// n = 0 for the first retry
 			logger := log.FromContext(ctx)
-			logger.V(3). //nolint:mnd // 3 is the verbosity level for detailed debug info
-					Info("error during mutating webhook socket connection, retrying...",
+			logger.V(loglevel.VerbosityDebug).
+				Info("error during mutating webhook socket connection, retrying...",
 					"attempt", n+1,
 					"error", err,
 				)

--- a/cspell.json
+++ b/cspell.json
@@ -88,7 +88,9 @@
         "runtimeenforcer",
         "agentv1",
         "failopen",
-        "ttrpc"
+        "ttrpc",
+        "loglevel",
+        "finalizer",
     ],
     "ignoreWords": [
         "clientgoscheme",

--- a/internal/controller/workloadpolicystatus_helpers.go
+++ b/internal/controller/workloadpolicystatus_helpers.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/loglevel"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 )
 
@@ -111,7 +112,7 @@ func (r *WorkloadPolicyStatusSync) processWorkloadPolicy(
 	// then trim to the most recent MaxViolationRecords entries.
 	newPolicy.Status.Violations = mergeViolations(wp.Status.Violations, scrapedViolations)
 
-	r.logger.V(1).Info("updating",
+	r.logger.V(loglevel.VerbosityDebug).Info("updating",
 		"policy", newPolicy.NamespacedName(),
 		"status", newPolicy.Status)
 	return r.Status().Update(ctx, newPolicy)

--- a/internal/controller/workloadpolicystatus_sync.go
+++ b/internal/controller/workloadpolicystatus_sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/grpcexporter"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/loglevel"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,7 +94,7 @@ func (r *WorkloadPolicyStatusSync) sync(
 	}
 
 	if len(wpList.Items) == 0 {
-		r.logger.V(1).Info("No WorkloadPolicies found, retrying later")
+		r.logger.V(loglevel.VerbosityDebug).Info("No WorkloadPolicies found, retrying later")
 		return nil
 	}
 

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -11,6 +11,7 @@ import (
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/proposalutils"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventscraper"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/loglevel"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,7 @@ func (r *LearningReconciler) handleAdmissionError(logger logr.Logger, err error)
 	case http.StatusGone:
 		// This happens when the top-level workload is deleted.
 		// We don't need to retry anymore.
-		logger.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+		logger.V(loglevel.VerbosityDebug).Info(
 			"Failed to update WorkloadPolicyProposal because the owner workload has been deleted",
 		)
 		return nil
@@ -151,8 +152,7 @@ func (r *LearningReconciler) Reconcile(
 
 		requeueAfter := r.ratelimiter.When(req)
 
-		//nolint:mnd // 3 is the verbosity level for detailed debug info
-		log.V(3).
+		log.V(loglevel.VerbosityDebug).
 			Info("Reconciliation failed due to conflict. Retry with backoff", "req", req, "delay", requeueAfter, "error", err)
 
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
@@ -174,7 +174,7 @@ func (r *LearningReconciler) reconcile(
 		"exe", req.ExecutablePath,
 	)
 
-	logger.V(3).Info("Reconciling", "req", req) //nolint:mnd // 3 is the verbosity level for detailed debug info
+	logger.V(loglevel.VerbosityDebug).Info("Reconciling", "req", req)
 
 	var err error
 	var proposalName string
@@ -182,7 +182,7 @@ func (r *LearningReconciler) reconcile(
 	if req.WorkloadKind == "Pod" {
 		// We don't support learning on standalone pods
 
-		logger.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+		logger.V(loglevel.VerbosityDebug).Info(
 			"Ignoring learning event",
 		)
 
@@ -193,7 +193,7 @@ func (r *LearningReconciler) reconcile(
 		var ns corev1.Namespace
 		if err = r.Client.Get(ctx, types.NamespacedName{Name: req.Namespace}, &ns); err != nil {
 			if apierrors.IsNotFound(err) {
-				logger.V(3).Info( //nolint:mnd // 3 is the verbosity level for detailed debug info
+				logger.V(loglevel.VerbosityDebug).Info(
 					"Namespace not found while evaluating learning namespace selector",
 				)
 				return ctrl.Result{}, nil
@@ -201,7 +201,7 @@ func (r *LearningReconciler) reconcile(
 			return ctrl.Result{}, fmt.Errorf("failed to get namespace %s: %w", req.Namespace, err)
 		}
 		if !r.namespaceSelector.Matches(labels.Set(ns.GetLabels())) {
-			logger.V(1).
+			logger.V(loglevel.VerbosityDebug).
 				Info("Namespace does not match learning namespace selector; skipping event", "namespace", req.Namespace)
 			return ctrl.Result{}, nil
 		}

--- a/internal/types/loglevel/loglevel.go
+++ b/internal/types/loglevel/loglevel.go
@@ -1,0 +1,10 @@
+package loglevel
+
+// Log verbosity levels for logr.Logger.V().
+// Higher values indicate more verbose output.
+const (
+	// VerbosityDebug is used for standard debug messages.
+	// Since we use `FromSlogHandler` all levels from 1 to 4 are mapped to Debug.
+	// Here we pick 1 as the default for debug messages.
+	VerbosityDebug = 1
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This linter is too noisy. I initially thought to just ignore the `logger.V(3).` pattern with a regex but in the end i realized it is also noisy in all other cases, so i just disabled it

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
