### PR TITLE
refactor: remove unused learning traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,12 +12,10 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
-	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.18.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.18.0
 	go.opentelemetry.io/otel/log v0.18.0
 	go.opentelemetry.io/otel/sdk/log v0.18.0
-	go.opentelemetry.io/otel/trace v1.42.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
 	golang.org/x/time v0.15.0
@@ -96,10 +94,12 @@ require (
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
+	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -11,9 +11,6 @@ import (
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler/proposalutils"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventscraper"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +46,6 @@ type LearningReconciler struct {
 
 	Scheme            *runtime.Scheme
 	eventChan         chan event.TypedGenericEvent[eventscraper.KubeProcessInfo]
-	tracer            trace.Tracer
 	namespaceSelector labels.Selector
 	// OwnerRefEnricher can be overridden during testing
 	OwnerRefEnricher func(wp *securityv1alpha1.WorkloadPolicyProposal, workloadKind string, workload string)
@@ -65,9 +61,6 @@ func NewLearningReconciler(
 		eventChan: make(
 			chan event.TypedGenericEvent[eventscraper.KubeProcessInfo],
 			DefaultEventChannelBufferSize,
-		),
-		tracer: otel.Tracer(
-			"runtime-enforcer-learner",
 		),
 		namespaceSelector: selector,
 		OwnerRefEnricher: func(wp *securityv1alpha1.WorkloadPolicyProposal, workloadKind string, workload string) {
@@ -226,9 +219,7 @@ func (r *LearningReconciler) reconcile(
 		},
 	}
 
-	var result controllerutil.OperationResult
-
-	if result, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {
+	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {
 		// We don't learn any new process if the policy proposal was promoted
 		// to an actual policy
 		labels := policyProposal.GetLabels()
@@ -253,24 +244,6 @@ func (r *LearningReconciler) reconcile(
 	}); err != nil {
 		return ctrl.Result{}, r.handleAdmissionError(logger, err)
 	}
-
-	// Emit trace when a new process is learned.
-	if result != controllerutil.OperationResultNone {
-		var span trace.Span
-		now := time.Now()
-		_, span = r.tracer.Start(ctx, "process learned")
-		span.SetAttributes(
-			attribute.String("evt.time", now.Format(time.RFC3339)),
-			attribute.Int64("evt.rawtime", now.UnixNano()),
-			attribute.String("k8s.ns.name", req.Namespace),
-			attribute.String("k8s.workload.kind", req.WorkloadKind),
-			attribute.String("k8s.workload.name", req.Workload),
-			attribute.String("container.name", req.ContainerName),
-			attribute.String("proc.exepath", req.ExecutablePath),
-		)
-		span.End()
-	}
-
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When we introduced violations, we removed the otel tracer initialization.
This is probably a leftover; these traces are never sent out from our agent.
I believe we might reintroduce them as logs/metrics when we need them for debugging.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
