### PR TITLE
refactor: use `NamespacedName` like in all other places

### DIFF
--- a/internal/controller/workloadpolicystatus_sync.go
+++ b/internal/controller/workloadpolicystatus_sync.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -13,7 +12,6 @@ import (
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -150,8 +148,7 @@ func (r *WorkloadPolicyStatusSync) sync(
 
 	// Now we iterate over all WSPs and update their status based on the collected policies status from the agents
 	for _, wp := range wpList.Items {
-		namespacedName := types.NamespacedName{Namespace: wp.Namespace, Name: wp.Name}
-		if err = r.processWorkloadPolicy(ctx, &wp, nodesInfo, violationsByPolicy[namespacedName]); err != nil {
+		if err = r.processWorkloadPolicy(ctx, &wp, nodesInfo, violationsByPolicy[wp.NamespacedName()]); err != nil {
 			r.logger.Error(
 				err,
 				"failed to process workload policy",
@@ -167,8 +164,8 @@ func (r *WorkloadPolicyStatusSync) sync(
 func (r *WorkloadPolicyStatusSync) getViolationsByPolicy(
 	ctx context.Context,
 	clients map[string]grpcexporter.AgentClientAPI,
-) map[types.NamespacedName][]v1alpha1.ViolationRecord {
-	violationsByPolicy := make(map[types.NamespacedName][]v1alpha1.ViolationRecord)
+) map[string][]v1alpha1.ViolationRecord {
+	violationsByPolicy := make(map[string][]v1alpha1.ViolationRecord)
 	for nodeName, client := range clients {
 		if client == nil {
 			r.logger.Info("cannot get a agent client for the node", "node", nodeName)
@@ -181,11 +178,7 @@ func (r *WorkloadPolicyStatusSync) getViolationsByPolicy(
 			continue
 		}
 		for _, v := range pbViolations {
-			namespacedName, parseErr := parsePolicyNamespacedName(v.GetPolicyName())
-			if parseErr != nil {
-				r.logger.Error(parseErr, "skipping violation record", "node", nodeName)
-				continue
-			}
+			namespacedName := v.GetPolicyName()
 			rec := v1alpha1.ViolationRecord{
 				Timestamp:      metav1.NewTime(v.GetTimestamp().AsTime()),
 				PodName:        v.GetPodName(),
@@ -199,15 +192,4 @@ func (r *WorkloadPolicyStatusSync) getViolationsByPolicy(
 	}
 
 	return violationsByPolicy
-}
-
-// parsePolicyNamespacedName parses a "namespace/name" string into a NamespacedName.
-// It returns an error if the string is not in the expected format, since all
-// policies are namespaced resources.
-func parsePolicyNamespacedName(s string) (types.NamespacedName, error) {
-	parts := strings.SplitN(s, "/", 2) //nolint:mnd // namespace/name pair
-	if len(parts) != 2 {               //nolint:mnd // namespace/name pair
-		return types.NamespacedName{}, fmt.Errorf("invalid policy name %q: expected namespace/name format", s)
-	}
-	return types.NamespacedName{Namespace: parts[0], Name: parts[1]}, nil
 }

--- a/internal/controller/workloadpolicystatus_test.go
+++ b/internal/controller/workloadpolicystatus_test.go
@@ -16,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -344,8 +343,8 @@ func TestGetViolationsByPolicy(t *testing.T) {
 
 		got := r.getViolationsByPolicy(context.Background(), clients)
 
-		nnA := types.NamespacedName{Namespace: "default", Name: "policy-a"}
-		nnB := types.NamespacedName{Namespace: "default", Name: "policy-b"}
+		nnA := "default/policy-a"
+		nnB := "default/policy-b"
 
 		require.Len(t, got[nnA], 2)
 		require.Contains(t, got[nnA], apiRec("pod-1", "node1"))
@@ -381,46 +380,4 @@ func TestGetViolationsByPolicy(t *testing.T) {
 		got := r.getViolationsByPolicy(context.Background(), nil)
 		require.Empty(t, got)
 	})
-}
-
-func TestParsePolicyNamespacedName(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    types.NamespacedName
-		wantErr bool
-	}{
-		{
-			name:  "valid namespace/name",
-			input: "default/my-policy",
-			want:  types.NamespacedName{Namespace: "default", Name: "my-policy"},
-		},
-		{
-			name:  "name with extra slashes",
-			input: "ns/name/with/slashes",
-			want:  types.NamespacedName{Namespace: "ns", Name: "name/with/slashes"},
-		},
-		{
-			name:    "no namespace",
-			input:   "just-a-name",
-			wantErr: true,
-		},
-		{
-			name:    "empty string",
-			input:   "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePolicyNamespacedName(tt.input)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The code seems easier without converting the NamespacedName to `types.NamespacedName`. I'm ok if we want to do that in all places, but in the current code, the method NamespacedName() is used almost in all places

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
