### PR TITLE
test: fix `BatchLookup` test behavior

### DIFF
--- a/internal/bpf/cgroup_policy_test.go
+++ b/internal/bpf/cgroup_policy_test.go
@@ -159,17 +159,29 @@ func TestBatchOperations(t *testing.T) {
 	///////////////////////
 
 	var cursor ebpf.MapBatchCursor
-	lookupKeys := []uint64{cgroup1, cgroup3}
-	lookupValues := make([]uint64, len(lookupKeys))
+	lookupKeys := make([]uint64, 2)
+	lookupValues := make([]uint64, 2)
 	// iterate over the buckets doesn't get the values associated with the keys.
 	// https://github.com/torvalds/linux/blob/1b237f190eb3d36f52dffe07a40b5eb210280e00/kernel/bpf/hashtab.c#L1677
-	count, err = cgToPol.BatchLookup(&cursor, lookupKeys, lookupValues, nil)
-	require.NoError(t, err, "Batch lookup failed")
-	require.Equal(t, len(lookupKeys), count, "Batch lookup did not find all entries")
+	_, _ = cgToPol.BatchLookup(&cursor, lookupKeys, lookupValues, nil)
+
+	// We cannot assert on the error since in case of partial read
+	// the operation could return ErrKeyNotExist
+	//
+	// require.NoError(t, err, "Batch lookup failed")
+
+	// Here we just ask for 2 keys in the map, but it is possible that we don't get all of them back.
+	// Example: we ask for 2 keys.
+	// - bucket 1 contains 1 element
+	// - bucket 2 contains 2 elements
+	// - the kernel cannot add that bucket without exceeding the remaining capacity
+	// - so it stops and returns only the 1 already collected
+	//
+	// require.Equal(t, len(lookupKeys), count, "Batch lookup did not find all entries")
 
 	// We cannot assert the values directly since the iteration order is not guaranteed.
 	//
-	// require.Equal(t, lookupValues, []uint64{
+	// require.Contains(t, lookupValues, []uint64{
 	// 	uint64(23),
 	// 	uint64(25),
 	// }, "Batch lookup did not return expected values")


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous assumption on `BatchLookup` was wrong. I updated the test and the doc, see the failure here https://github.com/rancher-sandbox/runtime-enforcer/pull/462#issuecomment-4120244644

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
