### PR TITLE
fix(ebpf): verifier issue when learning is disabled

### DIFF
--- a/bpf/main.c
+++ b/bpf/main.c
@@ -505,7 +505,12 @@ int BPF_PROG(enforce_cgroup_policy, struct linux_binprm *bprm) {
 	}
 
 	__u64 *policy_id = bpf_map_lookup_elem(&cg_to_policy_map, &cg_tracker_id);
-	if(!policy_id && load_time_config.learning_enabled) {
+	if(!policy_id) {
+		// if learning is disabled, nothing to do, we can return
+		if(!load_time_config.learning_enabled) {
+			return 0;
+		}
+
 		// No policy associated with this cgroup.
 		// Emit the event to the learning ringbuf so that the userspace can learn from it.
 		// This is critical because the LSM hook `security_bprm_creds_for_exec` is called

--- a/internal/bpf/verifier_test.go
+++ b/internal/bpf/verifier_test.go
@@ -6,13 +6,25 @@ import (
 
 // run it with: go test -v -run TestNoVerifierFailures ./internal/bpf -count=1 -exec "sudo -E".
 func TestNoVerifierFailures(t *testing.T) {
-	enableLearning := true
-	// Loading happens here so we can catch verifier errors without running the manager
-	_, err := NewManager(newTestLogger(t), enableLearning)
-	if err == nil {
-		t.Log("BPF manager started successfully :)!!")
-		return
+	tests := []struct {
+		name           string
+		enableLearning bool
+	}{
+		// We need to test both cases to be sure to catch any verifier errors
+		{name: "learning disabled", enableLearning: false},
+		{name: "learning enabled", enableLearning: true},
 	}
-	t.Log(err)
-	t.FailNow()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Loading happens here so we can catch verifier errors without running the manager
+			_, err := NewManager(newTestLogger(t), tt.enableLearning)
+			if err == nil {
+				t.Log("BPF manager started successfully :)!!")
+				return
+			}
+			t.Log(err)
+			t.FailNow()
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a verifier issue when the learning is disabled.

Verifier error
```
failed to load eBPF objects with stats verbosity: verifier error: field EnforceCgroupPolicy: program enforce_cgroup_policy: load program: permission denied: stack depth 160 (4 line(s) omitted). Dump: load program: permission denied:
        func 'security_bprm_creds_for_exec' arg0 has btf_id 7123 type STRUCT 'linux_binprm'
        R2 type=scalar expected=fp, pkt, pkt_meta, map_key, map_value, mem, ringbuf_mem, buf, trusted_ptr_
        verification time 1134 usec
        stack depth 160
        processed 342 insns (limit 1000000) max_states_per_insn 0 total_states 29 peak_states 29 mark_read 13
failed to load eBPF objects with branch verbosity: verifier error: field EnforceCgroupPolicy: program enforce_cgroup_policy: load program: permission denied: 1367: (85) call bpf_map_lookup_elem#1: R2 type=scalar expected=fp, pkt, pkt_meta, map_key, map_value, mem, ringbuf_mem, buf, trusted_ptr_ (285 line(s) omitted). Dump: load program: permission denied:
        0: R1=ctx() R10=fp0
        ; int BPF_PROG(enforce_cgroup_policy, struct linux_binprm *bprm) { @ main.c:498
        0: (79) r7 = *(u64 *)(r1 +0)
        func 'security_bprm_creds_for_exec' arg0 has btf_id 7123 type STRUCT 'linux_binprm'
        1: R1=ctx() R7_w=ptr_linux_binprm()
        1: (18) r1 = 0x1                      ; R1_w=1
        ; if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_cgroup_id) && @ main.c:218
        3: (15) if r1 == 0x0 goto pc+7        ; R1_w=1
        ; load_time_config.cgrp_fs_magic == CGROUP2_SUPER_MAGIC) { @ main.c:219
        4: (18) r1 = 0xffffcb32c32fa000       ; R1_w=map_value(map=.rodata,ks=4,vs=16)
        6: (79) r1 = *(u64 *)(r1 +0)          ; R1_w=0x63677270
        ; if(bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_get_current_cgroup_id) && @ main.c:218
        7: (55) if r1 != 0x63677270 goto pc+3         ; R1_w=0x63677270
        ; return bpf_get_current_cgroup_id(); @ main.c:220
        8: (85) call bpf_get_current_cgroup_id#80     ; R0=scalar()
        9: (bf) r6 = r0                       ; R0=scalar(id=1) R6_w=scalar(id=1)
        10: (05) goto pc+66
        ; return id; @ main.c:96
        77: (b7) r9 = 0                       ; R9_w=0
        ; if(!cgroupid) { @ main.c:234
        78: (15) if r6 == 0x0 goto pc+2502    ; R6_w=scalar(id=1,umin=1)
        79: (7b) *(u64 *)(r10 -88) = r6       ; R6_w=scalar(id=1,umin=1) R10=fp0 fp-88_w=scalar(id=1,umin=1)
        80: (bf) r2 = r10                     ; R2_w=fp0 R10=fp0
        81: (07) r2 += -88                    ; R2_w=fp-88
        ; ret = bpf_map_lookup_elem(&cgtracker_map, &cgid); @ main.c:36
        82: (18) r1 = 0xffff8986054bf800      ; R1_w=map_ptr(map=cgtracker_map,ks=8,vs=8)
        84: (85) call bpf_map_lookup_elem#1   ; R0=map_value_or_null(id=2,map=cgtracker_map,ks=8,vs=8)
        ; return ret ? *ret : 0; @ main.c:37
        85: (55) if r0 != 0x0 goto pc+1 87: R0=map_value(map=cgtracker_map,ks=8,vs=8) R6=scalar(id=1,umin=1) R7=ptr_linux_binprm() R9=0 R10=fp0 fp-88=scalar(id=1,umin=1)
        ; return ret ? *ret : 0; @ main.c:37
        87: (79) r1 = *(u64 *)(r0 +0)         ; R0=map_value(map=cgtracker_map,ks=8,vs=8) R1_w=scalar()
        ; __u64 cg_tracker_id = get_tracker_id_from_curr_task(); @ main.c:499
        88: (7b) *(u64 *)(r10 -120) = r1      ; R1_w=scalar(id=3) R10=fp0 fp-120_w=scalar(id=3)
        ; if(cg_tracker_id == 0) { @ main.c:500
        89: (15) if r1 == 0x0 goto pc+2491    ; R1_w=scalar(id=3,umin=1)
        90: (bf) r2 = r10                     ; R2_w=fp0 R10=fp0
        91: (07) r2 += -120                   ; R2_w=fp-120
        ; __u64 *policy_id = bpf_map_lookup_elem(&cg_to_policy_map, &cg_tracker_id); @ main.c:507
        92: (18) r1 = 0xffff8986054bbc00      ; R1_w=map_ptr(map=cg_to_policy_ma,ks=8,vs=8)
        94: (85) call bpf_map_lookup_elem#1   ; R0=map_value_or_null(id=4,map=cg_to_policy_ma,ks=8,vs=8)
        95: (bf) r6 = r0                      ; R0=map_value_or_null(id=4,map=cg_to_policy_ma,ks=8,vs=8) R6_w=map_value_or_null(id=4,map=cg_to_policy_ma,ks=8,vs=8)
        ; if(!policy_id && load_time_config.learning_enabled) { @ main.c:508
        96: (55) if r6 != 0x0 goto pc+32      ; R6_w=0
        97: (18) r1 = 0xffffcb32c32fa000      ; R1_w=map_value(map=.rodata,ks=4,vs=16)
        99: (71) r1 = *(u8 *)(r1 +13)         ; R1_w=0
        100: (15) if r1 == 0x0 goto pc+28     ; R1_w=0
        ; bpf_printk("Failed to reserve space for log event in ring buffer\n"); @ main.c:253
        129: (b7) r1 = 0                      ; R1_w=0
        ; int zero = 0; @ main.c:412
        130: (63) *(u32 *)(r10 -32) = r1      ; R1_w=0 R10=fp0 fp-32=????0
        131: (bf) r2 = r10                    ; R2_w=fp0 R10=fp0
        132: (07) r2 += -32                   ; R2_w=fp-32
        ; (struct process_evt *)bpf_map_lookup_elem(&process_evt_storage_map, &zero); @ main.c:414
        133: (18) r1 = 0xffff897ac7b3c000     ; R1_w=map_ptr(map=process_evt_sto,ks=4,vs=12304)
        135: (85) call bpf_map_lookup_elem#1          ; R0=map_value(map=process_evt_sto,ks=4,vs=12304)
        ; if(!evt) { @ main.c:415
        136: (55) if r0 != 0x0 goto pc+16     ; R0=map_value(map=process_evt_sto,ks=4,vs=12304)
        ; evt->cg_tracker_id = cg_tracker_id; @ main.c:553
        153: (79) r1 = *(u64 *)(r10 -120)     ; R1_w=scalar(id=3,umin=1) R10=fp0 fp-120=scalar(id=3,umin=1)
        154: (7b) *(u64 *)(r0 +0) = r1        ; R0=map_value(map=process_evt_sto,ks=4,vs=12304) R1_w=scalar(id=3,umin=1)
        ; struct file *file = bprm->file; @ main.c:391
        155: (79) r7 = *(u64 *)(r7 +64)       ; R7_w=ptr_file()
        ; if(file == NULL) { @ main.c:392
        156: (55) if r7 != 0x0 goto pc+14 171: R0=map_value(map=process_evt_sto,ks=4,vs=12304) R1=scalar(id=3,umin=1) R6=0 R7=ptr_file() R9=0 R10=fp0 fp-32=????0 fp-88=scalar(id=1,umin=1) fp-120=scalar(id=3,umin=1)
        ; bpf_printk("Failed to reserve space for log event in ring buffer\n"); @ main.c:253
        171: (7b) *(u64 *)(r10 -152) = r6     ; R6=0 R10=fp0 fp-152_w=0
        172: (7b) *(u64 *)(r10 -144) = r0     ; R0=map_value(map=process_evt_sto,ks=4,vs=12304) R10=fp0 fp-144_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        173: (b7) r1 = 64                     ; R1_w=64
        174: (b7) r2 = 0                      ; R2_w=0
        ; struct dentry *dentry = NULL; @ d_path_resolution.h:125
        175: (7b) *(u64 *)(r10 -32) = r2      ; R2_w=0 R10=fp0 fp-32_w=0
        176: (0f) r7 += r1                    ; R1_w=64 R7_w=ptr_file(off=64)
        177: (b7) r1 = 8                      ; R1_w=8
        178: (bf) r3 = r7                     ; R3_w=ptr_file(off=64) R7_w=ptr_file(off=64)
        179: (0f) r3 += r1                    ; R1_w=8 R3_w=ptr_file(off=72)
        180: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        181: (07) r1 += -32                   ; R1_w=fp-32
        ; if(bpf_core_read(&dentry, sizeof(dentry), &path->dentry) != 0) { @ d_path_resolution.h:126
        182: (b7) r2 = 8                      ; R2_w=8
        183: (85) call bpf_probe_read_kernel#113      ; R0_w=scalar() fp-32_w=mmmmmmmm
        184: (55) if r0 != 0x0 goto pc+453    ; R0_w=0
        185: (79) r1 = *(u64 *)(r10 -144)     ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304) R10=fp0 fp-144_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        186: (07) r1 += 11                    ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        187: (7b) *(u64 *)(r10 -160) = r1     ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11) R10=fp0 fp-160_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        188: (b7) r1 = 8                      ; R1_w=8
        ; if(d_unlinked(dentry)) { @ d_path_resolution.h:130
        189: (79) r6 = *(u64 *)(r10 -32)      ; R6_w=scalar() R10=fp0 fp-32_w=mmmmmmmm
        190: (bf) r3 = r6                     ; R3_w=scalar(id=9) R6_w=scalar(id=9)
        191: (0f) r3 += r1                    ; R1_w=8 R3_w=scalar(id=9+8)
        192: (b7) r1 = 8                      ; R1_w=8
        193: (0f) r3 += r1                    ; R1_w=8 R3_w=scalar()
        194: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        195: (07) r1 += -88                   ; R1_w=fp-88
        ; bpf_core_read(&pprev, sizeof(pprev), &h->pprev); @ d_path_resolution.h:42
        196: (b7) r2 = 8                      ; R2_w=8
        197: (85) call bpf_probe_read_kernel#113      ; R0=scalar() fp-88=mmmmmmmm
        198: (b7) r8 = 8192                   ; R8_w=8192
        ; return !pprev; @ d_path_resolution.h:43
        199: (79) r1 = *(u64 *)(r10 -88)      ; R1_w=scalar() R10=fp0 fp-88=mmmmmmmm
        ; return d_unhashed(dentry) && !IS_ROOT(dentry); @ d_path_resolution.h:51
        200: (55) if r1 != 0x0 goto pc+28     ; R1_w=0
        201: (b7) r1 = 24                     ; R1_w=24
        202: (bf) r3 = r6                     ; R3_w=scalar(id=9) R6=scalar(id=9)
        203: (0f) r3 += r1                    ; R1_w=24 R3_w=scalar(id=9+24)
        204: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        205: (07) r1 += -88                   ; R1_w=fp-88
        ; bpf_core_read(&d_parent, sizeof(d_parent), &dentry->d_parent); @ d_path_resolution.h:36
        206: (b7) r2 = 8                      ; R2_w=8
        207: (85) call bpf_probe_read_kernel#113      ; R0=scalar() fp-88=mmmmmmmm
        ; return (dentry == d_parent); @ d_path_resolution.h:37
        208: (79) r1 = *(u64 *)(r10 -88)      ; R1_w=scalar() R10=fp0 fp-88=mmmmmmmm
        ; if(d_unlinked(dentry)) { @ d_path_resolution.h:130
        209: (1d) if r6 == r1 goto pc+19      ; R1_w=scalar() R6=scalar(id=9)
        210: (b7) r1 = 41                     ; R1_w=41
        211: (79) r2 = *(u64 *)(r10 -144)     ; R2_w=map_value(map=process_evt_sto,ks=4,vs=12304) R10=fp0 fp-144=map_value(map=process_evt_sto,ks=4,vs=12304)
        ; memcpy(&buf[SAFE_PATH_ACCESS(off)], DELETED_STRING, sizeof(DELETED_STRING) - 1); @ d_path_resolution.h:134
        212: (73) *(u8 *)(r2 +8202) = r1      ; R1_w=41 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        213: (b7) r1 = 116                    ; R1_w=116
        214: (73) *(u8 *)(r2 +8199) = r1      ; R1_w=116 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        215: (b7) r1 = 108                    ; R1_w=108
        216: (73) *(u8 *)(r2 +8197) = r1      ; R1_w=108 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        217: (b7) r1 = 101                    ; R1_w=101
        218: (73) *(u8 *)(r2 +8200) = r1      ; R1_w=101 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        219: (73) *(u8 *)(r2 +8198) = r1      ; R1_w=101 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        220: (73) *(u8 *)(r2 +8196) = r1      ; R1_w=101 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        221: (b7) r1 = 100                    ; R1_w=100
        222: (73) *(u8 *)(r2 +8201) = r1      ; R1_w=100 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        223: (73) *(u8 *)(r2 +8195) = r1      ; R1_w=100 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        224: (b7) r1 = 40                     ; R1_w=40
        225: (73) *(u8 *)(r2 +8194) = r1      ; R1_w=40 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        226: (b7) r1 = 32                     ; R1_w=32
        227: (73) *(u8 *)(r2 +8193) = r1      ; R1_w=32 R2_w=map_value(map=process_evt_sto,ks=4,vs=12304)
        228: (b7) r8 = 8182                   ; R8_w=8182
        ; struct path_read_data data = { @ d_path_resolution.h:137
        229: (79) r1 = *(u64 *)(r10 -160)     ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11) R10=fp0 fp-160=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        230: (7b) *(u64 *)(r10 -48) = r1      ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11) R10=fp0 fp-48_w=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        231: (7b) *(u64 *)(r10 -40) = r9      ; R9=0 R10=fp0 fp-40_w=0
        232: (63) *(u32 *)(r10 -40) = r8      ; R8_w=8182 R10=fp0 fp-40_w=mmmm8182
        233: (7b) *(u64 *)(r10 -56) = r9      ; R9=0 R10=fp0 fp-56_w=0
        234: (7b) *(u64 *)(r10 -64) = r9      ; R9=0 R10=fp0 fp-64_w=0
        235: (7b) *(u64 *)(r10 -72) = r9      ; R9=0 R10=fp0 fp-72_w=0
        236: (7b) *(u64 *)(r10 -80) = r9      ; R9=0 R10=fp0 fp-80_w=0
        237: (7b) *(u64 *)(r10 -88) = r9      ; R9=0 R10=fp0 fp-88_w=0
        ; struct fs_struct *fs = NULL; @ d_path_resolution.h:142
        238: (7b) *(u64 *)(r10 -96) = r9      ; R9=0 R10=fp0 fp-96_w=0
        ; struct task_struct *task = (struct task_struct *)bpf_get_current_task(); @ d_path_resolution.h:143
        239: (85) call bpf_get_current_task#35        ; R0=scalar()
        240: (b7) r1 = 3312                   ; R1_w=3312
        241: (0f) r0 += r1                    ; R0_w=scalar() R1_w=3312
        242: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        243: (07) r1 += -96                   ; R1_w=fp-96
        ; bpf_core_read(&fs, sizeof(fs), &task->fs); @ d_path_resolution.h:144
        244: (b7) r2 = 8                      ; R2_w=8
        245: (bf) r3 = r0                     ; R0_w=scalar(id=10) R3_w=scalar(id=10)
        246: (85) call bpf_probe_read_kernel#113      ; R0_w=scalar() fp-96=mmmmmmmm
        ; struct path *root = NULL; @ d_path_resolution.h:145
        247: (7b) *(u64 *)(r10 -104) = r9     ; R9=0 R10=fp0 fp-104_w=0
        248: (b7) r1 = 24                     ; R1_w=24
        ; bpf_core_read(&root, sizeof(root), &fs->root); @ d_path_resolution.h:146
        249: (79) r3 = *(u64 *)(r10 -96)      ; R3_w=scalar() R10=fp0 fp-96=mmmmmmmm
        250: (0f) r3 += r1                    ; R1_w=24 R3_w=scalar()
        251: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        252: (07) r1 += -104                  ; R1_w=fp-104
        253: (b7) r2 = 8                      ; R2_w=8
        254: (85) call bpf_probe_read_kernel#113      ; R0=scalar() fp-104=mmmmmmmm
        255: (b7) r6 = 8                      ; R6_w=8
        ; bpf_core_read(&data.root_dentry, sizeof(data.root_dentry), &root->dentry); @ d_path_resolution.h:149
        256: (79) r3 = *(u64 *)(r10 -104)     ; R3_w=scalar() R10=fp0 fp-104=mmmmmmmm
        257: (0f) r3 += r6                    ; R3_w=scalar() R6_w=8
        258: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        259: (07) r1 += -88                   ; R1_w=fp-88
        260: (b7) r2 = 8                      ; R2_w=8
        261: (85) call bpf_probe_read_kernel#113      ; R0_w=scalar() fp-88=mmmmmmmm
        262: (b7) r8 = 0                      ; R8_w=0
        ; bpf_core_read(&data.root_mnt, sizeof(data.root_mnt), &root->mnt); @ d_path_resolution.h:150
        263: (79) r3 = *(u64 *)(r10 -104)     ; R3_w=scalar() R10=fp0 fp-104=mmmmmmmm
        264: (0f) r3 += r8                    ; R3_w=scalar() R8_w=0
        ; struct path_read_data data = { @ d_path_resolution.h:137
        265: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        266: (07) r1 += -80                   ; R1_w=fp-80
        ; bpf_core_read(&data.root_mnt, sizeof(data.root_mnt), &root->mnt); @ d_path_resolution.h:150
        267: (b7) r2 = 8                      ; R2_w=8
        268: (85) call bpf_probe_read_kernel#113      ; R0=scalar() fp-80=mmmmmmmm
        269: (bf) r3 = r7                     ; R3_w=ptr_file(off=64) R7=ptr_file(off=64)
        270: (0f) r3 += r6                    ; R3_w=ptr_file(off=72) R6=8
        ; struct path_read_data data = { @ d_path_resolution.h:137
        271: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        272: (07) r1 += -72                   ; R1_w=fp-72
        273: (7b) *(u64 *)(r10 -128) = r1     ; R1_w=fp-72 R10=fp0 fp-128_w=fp-72
        ; bpf_core_read(&data.dentry, sizeof(data.dentry), &path->dentry); @ d_path_resolution.h:152
        274: (b7) r2 = 8                      ; R2_w=8
        275: (85) call bpf_probe_read_kernel#113      ; R0_w=scalar() fp-72=mmmmmmmm
        276: (0f) r7 += r8                    ; R7_w=ptr_file(off=64) R8=0
        ; struct path_read_data data = { @ d_path_resolution.h:137
        277: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0
        278: (07) r1 += -64                   ; R1_w=fp-64
        ; bpf_core_read(&data.vfsmnt, sizeof(data.vfsmnt), &path->mnt); @ d_path_resolution.h:153
        279: (b7) r2 = 8                      ; R2_w=8
        280: (bf) r3 = r7                     ; R3_w=ptr_file(off=64) R7_w=ptr_file(off=64)
        281: (85) call bpf_probe_read_kernel#113      ; R0=scalar() fp-64=mmmmmmmm
        282: (b7) r2 = 32                     ; R2_w=32
        ; data.mnt = container_of( @ d_path_resolution.h:154
        283: (79) r1 = *(u64 *)(r10 -64)      ; R1_w=scalar() R10=fp0 fp-64=mmmmmmmm
        284: (1f) r1 -= r2                    ; R1_w=scalar() R2_w=32
        285: (7b) *(u64 *)(r10 -56) = r1      ; R1_w=scalar(id=11) R10=fp0 fp-56_w=scalar(id=11)
        ; if(bpf_ksym_exists(bpf_iter_num_new)) { @ d_path_resolution.h:159
        286: (18) r1 = 0x23a77                ; R1_w=0x23a77
        288: (55) if r1 != 0x0 goto pc+106    ; R1_w=0x23a77
        ; if(cgrp_fs_ver == CGROUP2_SUPER_MAGIC) { @ main.c:166
        395: (bf) r6 = r10                    ; R6_w=fp0 R10=fp0
        396: (07) r6 += -112                  ; R6_w=fp-112
        ; bpf_repeat(PATH_ITERATIONS) { @ d_path_resolution.h:171
        397: (bf) r1 = r6                     ; R1_w=fp-112 R6_w=fp-112
        398: (b7) r2 = 0                      ; R2_w=0
        399: (b7) r3 = 2048                   ; R3_w=2048
        400: (85) call bpf_iter_num_new#146039        ; R0=scalar() fp-112=iter_num(ref_id=12,state=active,depth=0) refs=12
        401: (bf) r1 = r6                     ; R1=fp-112 R6=fp-112 refs=12
        402: (85) call bpf_iter_num_next#146041       ; R0_w=0 fp-112=iter_num(ref_id=12,state=drained,depth=0) refs=12
        403: (15) if r0 == 0x0 goto pc+97     ; R0_w=0 refs=12
        501: (bf) r1 = r10                    ; R1_w=fp0 R10=fp0 refs=12
        502: (07) r1 += -112                  ; R1_w=fp-112 refs=12
        503: (85) call bpf_iter_num_destroy#146037    ;
        ; } else { @ d_path_resolution.h:176
        504: (05) goto pc+46
        ; if(data.curr_off == MAX_PATH_LEN * 2) { @ d_path_resolution.h:186
        551: (61) r6 = *(u32 *)(r10 -40)      ; R6_w=8182 R10=fp0 fp-40=mmmm8182
        552: (55) if r6 != 0x2000 goto pc+83          ; R6_w=8182
        ; if(data.resolved) { @ d_path_resolution.h:193
        636: (71) r1 = *(u8 *)(r10 -36)       ; R1_w=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff)) R10=fp0 fp-40=mmmm8182
        637: (55) if r1 != 0x0 goto pc+42 680: R1=scalar(smin=umin=smin32=umin32=1,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff)) R6=8182 R7=ptr_file(off=64) R8=0 R9=0 R10=fp0 fp-32=mmmmmmmm fp-40=mmmm8182 fp-48=map_value(map=process_evt_sto,ks=4,vs=12304,off=11) fp-56=scalar(id=11) fp-64=mmmmmmmm fp-72=mmmmmmmm fp-80=mmmmmmmm fp-88=mmmmmmmm fp-96=mmmmmmmm fp-104=mmmmmmmm fp-120=scalar(id=3,umin=1) fp-128=fp-72 fp-144=map_value(map=process_evt_sto,ks=4,vs=12304) fp-152=0 fp-160=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        ; if(current_offset == 0) { @ main.c:398
        680: (15) if r6 == 0x2000 goto pc+248         ; R6=8182
        681: (55) if r6 != 0x0 goto pc+262    ; R6=8182
        ; bpf_printk("Failed to reserve space for log event in ring buffer\n"); @ main.c:253
        944: (b7) r2 = 8192                   ; R2_w=8192
        ; evt->path_len = MAX_PATH_LEN * 2 - current_offset; @ main.c:407
        945: (1f) r2 -= r6                    ; R2_w=10 R6=8182
        946: (79) r1 = *(u64 *)(r10 -144)     ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304) R10=fp0 fp-144=map_value(map=process_evt_sto,ks=4,vs=12304)
        947: (6b) *(u16 *)(r1 +8) = r2        ; R1_w=map_value(map=process_evt_sto,ks=4,vs=12304) R2_w=10
        ; if(LINUX_KERNEL_VERSION < KERNEL_VERSION(5, 11, 0)) { @ main.c:567
        948: (18) r1 = 0xffff897ac7b3e508     ; R1_w=map_value(map=.kconfig,ks=4,vs=4)
        950: (61) r1 = *(u32 *)(r1 +0)        ; R1_w=0x61109
        951: (67) r1 <<= 32                   ; R1_w=0x6110900000000
        952: (c7) r1 s>>= 32                  ; R1=0x61109
        953: (65) if r1 s> 0x50aff goto pc+101        ; R1=0x61109
        ; if(len < STRING_MAPS_SIZE_5) { @ main.c:451
        1055: (bf) r1 = r2                    ; R1_w=10 R2=10
        1056: (57) r1 &= 65535                ; R1_w=10
        1057: (25) if r1 > 0x8f goto pc+118   ; R1_w=10
        ; if(len % STRING_MAPS_KEY_INC_SIZE != 0) { @ main.c:452
        1058: (bf) r3 = r2                    ; R2=10 R3_w=10
        1059: (57) r3 &= 255                  ; R3_w=10
        1060: (27) r3 *= 171                  ; R3_w=1710
        1061: (77) r3 >>= 12                  ; R3_w=0
        1062: (27) r3 *= 24                   ; R3_w=0
        1063: (bf) r1 = r2                    ; R1_w=10 R2=10
        1064: (1f) r1 -= r3                   ; R1_w=10 R3_w=0
        1065: (57) r1 &= 255                  ; R1_w=10
        1066: (79) r7 = *(u64 *)(r10 -160)    ; R7=map_value(map=process_evt_sto,ks=4,vs=12304,off=11) R10=fp0 fp-160=map_value(map=process_evt_sto,ks=4,vs=12304,off=11)
        1067: (15) if r1 == 0x0 goto pc+184   ; R1=10
        ; padded_len = ((len / STRING_MAPS_KEY_INC_SIZE) + 1) * STRING_MAPS_KEY_INC_SIZE; @ main.c:453
        1068: (1f) r2 -= r1                   ; R1=10 R2_w=0
        1069: (bf) r1 = r2                    ; R1_w=0 R2_w=0
        1070: (07) r1 += 24                   ; R1_w=24
        ; if(padded_len < STRING_MAPS_SIZE_5) { @ main.c:478
        1071: (bf) r3 = r1                    ; R1_w=24 R3_w=24
        1072: (57) r3 &= 65535                ; R3_w=24
        ; padded_len = ((len / STRING_MAPS_KEY_INC_SIZE) + 1) * STRING_MAPS_KEY_INC_SIZE; @ main.c:453
        1073: (bf) r4 = r2                    ; R2_w=0 R4_w=0
        1074: (57) r4 &= 65535                ; R4_w=0
        1075: (b7) r5 = 120                   ; R5_w=120
        1076: (bf) r2 = r1                    ; R1_w=24 R2_w=24
        ; if(padded_len < STRING_MAPS_SIZE_5) { @ main.c:478
        1077: (2d) if r5 > r4 goto pc+174     ; R4_w=0 R5_w=120
        ; return (padded_len / STRING_MAPS_KEY_INC_SIZE) - 1; @ main.c:479
        1252: (57) r2 &= 255                  ; R2_w=24
        1253: (27) r2 *= 171                  ; R2_w=4104
        1254: (77) r2 >>= 12                  ; R2_w=1
        ; switch(index) { @ string_maps.h:83
        1255: (65) if r2 s> 0x3 goto pc+55    ; R2_w=1
        1256: (18) r1 = 0xffff8986054b9800    ; R1_w=map_ptr(map=pol_str_maps_0,ks=8,vs=4)
        1258: (15) if r2 == 0x1 goto pc+107   ; R2_w=1
        ; return ret ? *ret : 0; @ main.c:37
        1366: (79) r2 = *(u64 *)(r10 -152)    ; R2_w=0 R10=fp0 fp-152=0
        1367: (85) call bpf_map_lookup_elem#1
        R2 type=scalar expected=fp, pkt, pkt_meta, map_key, map_value, mem, ringbuf_mem, buf, trusted_ptr_
        processed 342 insns (limit 1000000) max_states_per_insn 0 total_states 29 peak_states 29 mark_read 13
    verifier_test.go:26: failed to load eBPF objects
```

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
