### PR TITLE
feat: cumulative violation count to WorkloadPolicy status

### DIFF
--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -91,6 +91,15 @@ type WorkloadPolicyStatus struct {
 	NodesTransitioning []string `json:"nodesTransitioning,omitempty"`
 	// phase indicates the current phase of the workload policy.
 	Phase Phase `json:"phase,omitempty"`
+	// violationCount is the total number of violation records,
+	// including those no longer retained in violations.
+	//
+	// Note: This value is maintained by the reconciler and reflects
+	// its best-effort view of the system. It is not guaranteed to be
+	// strongly consistent and may be temporarily outdated depending on
+	// reconciliation.
+	// +optional
+	ViolationCount int64 `json:"violationCount,omitempty"`
 	// violations is the list of the most recent violation records (max MaxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	// +optional

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
@@ -125,6 +125,17 @@ spec:
                 description: transitioningNodes is the number of nodes where the policy
                   is transitioning mode.
                 type: integer
+              violationCount:
+                description: |-
+                  violationCount is the total number of violation records,
+                  including those no longer retained in violations.
+
+                  Note: This value is maintained by the reconciler and reflects
+                  its best-effort view of the system. It is not guaranteed to be
+                  strongly consistent and may be temporarily outdated depending on
+                  reconciliation.
+                format: int64
+                type: integer
               violations:
                 description: |-
                   violations is the list of the most recent violation records (max MaxViolationRecords).

--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -312,6 +312,13 @@ Required: \{} +
 | *`transitioningNodes`* __integer__ | transitioningNodes is the number of nodes where the policy is transitioning mode. + |  | 
 | *`nodesTransitioning`* __string array__ | nodesTransitioning contains the names of the nodes that are transitioning. + |  | 
 | *`phase`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-phase[$$Phase$$]__ | phase indicates the current phase of the workload policy. + |  | 
+| *`violationCount`* __integer__ | violationCount is the total number of violation records, +
+including those no longer retained in violations. +
+
+Note: This value is maintained by the reconciler and reflects +
+its best-effort view of the system. It is not guaranteed to be +
+strongly consistent and may be temporarily outdated depending on +
+reconciliation. + |  | 
 | *`violations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-violationrecord[$$ViolationRecord$$] array__ | violations is the list of the most recent violation records (max MaxViolationRecords). +
 Oldest entries are dropped when the limit is reached. + |  | 
 |===

--- a/internal/controller/workloadpolicystatus_helpers.go
+++ b/internal/controller/workloadpolicystatus_helpers.go
@@ -94,23 +94,40 @@ func computeWpStatus(
 	return status, nil
 }
 
+func buildPolicyStatus(
+	wp *v1alpha1.WorkloadPolicy,
+	nodesInfo nodesInfoMap,
+	scrapedViolations []v1alpha1.ViolationRecord,
+) (v1alpha1.WorkloadPolicyStatus, error) {
+	newStatus, err := computeWpStatus(nodesInfo, convertToPolicyMode(wp.Spec.Mode), wp.NamespacedName())
+	if err != nil {
+		return v1alpha1.WorkloadPolicyStatus{}, fmt.Errorf(
+			"failed to compute status for policy %s: %w",
+			wp.NamespacedName(),
+			err,
+		)
+	}
+	newStatus.ObservedGeneration = wp.Generation
+
+	// Merge scraped violations into status: prepend new violations to existing,
+	// then trim to the most recent MaxViolationRecords entries.
+	newStatus.Violations = mergeViolations(wp.Status.Violations, scrapedViolations)
+	newStatus.ViolationCount = wp.Status.ViolationCount + int64(len(scrapedViolations))
+	return newStatus, nil
+}
+
 func (r *WorkloadPolicyStatusSync) processWorkloadPolicy(
 	ctx context.Context,
 	wp *v1alpha1.WorkloadPolicy,
 	nodesInfo nodesInfoMap,
 	scrapedViolations []v1alpha1.ViolationRecord,
 ) error {
-	expectedMode := convertToPolicyMode(wp.Spec.Mode)
-	newPolicy := wp.DeepCopy()
-	var err error
-	if newPolicy.Status, err = computeWpStatus(nodesInfo, expectedMode, newPolicy.NamespacedName()); err != nil {
-		return fmt.Errorf("failed to compute status for policy %s: %w", newPolicy.NamespacedName(), err)
+	status, err := buildPolicyStatus(wp, nodesInfo, scrapedViolations)
+	if err != nil {
+		return err
 	}
-	newPolicy.Status.ObservedGeneration = wp.Generation
-
-	// Merge scraped violations into status: prepend new violations to existing,
-	// then trim to the most recent MaxViolationRecords entries.
-	newPolicy.Status.Violations = mergeViolations(wp.Status.Violations, scrapedViolations)
+	newPolicy := wp.DeepCopy()
+	newPolicy.Status = status
 
 	r.logger.V(loglevel.VerbosityDebug).Info("updating",
 		"policy", newPolicy.NamespacedName(),

--- a/internal/controller/workloadpolicystatus_test.go
+++ b/internal/controller/workloadpolicystatus_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/grpcexporter"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -294,6 +295,30 @@ func TestMergeViolations(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func TestWorkloadPolicyViolationCount(t *testing.T) {
+	wp := &v1alpha1.WorkloadPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "ns",
+		},
+		Spec: v1alpha1.WorkloadPolicySpec{Mode: policymode.MonitorString},
+		Status: v1alpha1.WorkloadPolicyStatus{
+			ViolationCount: 1,
+			Violations:     []v1alpha1.ViolationRecord{makeRecord(1)},
+		},
+	}
+	scraped := make([]v1alpha1.ViolationRecord, v1alpha1.MaxViolationRecords)
+	for i := range scraped {
+		scraped[i] = makeRecord(i + 2)
+	}
+
+	status, err := buildPolicyStatus(wp, nil, scraped)
+	require.NoError(t, err)
+
+	require.Equal(t, int64(101), status.ViolationCount)
+	require.Len(t, status.Violations, v1alpha1.MaxViolationRecords)
 }
 
 func TestGetViolationsByPolicy(t *testing.T) {

--- a/pkg/generated/applyconfiguration/api/v1alpha1/workloadpolicystatus.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha1/workloadpolicystatus.go
@@ -24,6 +24,14 @@ type WorkloadPolicyStatusApplyConfiguration struct {
 	NodesTransitioning []string `json:"nodesTransitioning,omitempty"`
 	// phase indicates the current phase of the workload policy.
 	Phase *apiv1alpha1.Phase `json:"phase,omitempty"`
+	// violationCount is the total number of violation records,
+	// including those no longer retained in violations.
+	//
+	// Note: This value is maintained by the reconciler and reflects
+	// its best-effort view of the system. It is not guaranteed to be
+	// strongly consistent and may be temporarily outdated depending on
+	// reconciliation.
+	ViolationCount *int64 `json:"violationCount,omitempty"`
 	// violations is the list of the most recent violation records (max MaxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	Violations []ViolationRecordApplyConfiguration `json:"violations,omitempty"`
@@ -104,6 +112,14 @@ func (b *WorkloadPolicyStatusApplyConfiguration) WithNodesTransitioning(values .
 // If called multiple times, the Phase field is set to the value of the last call.
 func (b *WorkloadPolicyStatusApplyConfiguration) WithPhase(value apiv1alpha1.Phase) *WorkloadPolicyStatusApplyConfiguration {
 	b.Phase = &value
+	return b
+}
+
+// WithViolationCount sets the ViolationCount field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ViolationCount field is set to the value of the last call.
+func (b *WorkloadPolicyStatusApplyConfiguration) WithViolationCount(value int64) *WorkloadPolicyStatusApplyConfiguration {
+	b.ViolationCount = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -163,6 +163,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: transitioningNodes
       type:
         scalar: numeric
+    - name: violationCount
+      type:
+        scalar: numeric
     - name: violations
       type:
         list:

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -549,6 +549,13 @@ func schema_rancher_sandbox_runtime_enforcer_api_v1alpha1_WorkloadPolicyStatus(r
 							Format:      "",
 						},
 					},
+					"violationCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "violationCount is the total number of violation records, including those no longer retained in violations.\n\nNote: This value is maintained by the reconciler and reflects its best-effort view of the system. It is not guaranteed to be strongly consistent and may be temporarily outdated depending on reconciliation.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"violations": {
 						SchemaProps: spec.SchemaProps{
 							Description: "violations is the list of the most recent violation records (max MaxViolationRecords). Oldest entries are dropped when the limit is reached.",


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
This PR add `violationCount` to track the total number of violations ever reported for a given policy, regardless of how many individual records are retained in the violations array.

**Which issue(s) this PR fixes**

fixes #482 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
