### PR TITLE
chore: update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,41 @@ updates:
           - "k8s.io/code-generator"
           - "k8s.io/component-base"
           - "sigs.k8s.io/controller-runtime"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/attestation/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/bpfvalidator/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/container-build/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/merge-multiarch/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Currently our dependabot doesn't update dependencies under `.github/actions`, which makes them become pretty out-of-date.  This PR enables dependabot to update those dependencies. 

Sample PRs:

<img width="820" height="515" alt="image" src="https://github.com/user-attachments/assets/c01a5776-a251-4827-aaf9-8e4f9ced7178" />

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
