### PR TITLE
chore: pin commitlint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,16 +76,12 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    env:
+      COMMITLINT_VERSION: "20.5.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Discover latest version of commitlint
-        id: discover-commitlint-version
-        run: |
-          latest_version=$(curl -s https://api.github.com/repos/conventional-changelog/commitlint/releases/latest | jq -r '.tag_name')
-          echo "version=$latest_version" >> $GITHUB_OUTPUT
-        shell: bash
       - name: Cache commitlint
         id: cache-commitlint
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -94,10 +90,10 @@ jobs:
             node_modules
             package.json
             package-lock.json
-          key: ${{ runner.os }}-commitlint-${{ steps.discover-commitlint-version.outputs.version }}
+          key: ${{ runner.os }}-commitlint-${{ env.COMMITLINT_VERSION }}
       - name: Install commitlint
         if: steps.cache-commitlint.outputs.cache-hit != 'true'
-        run: npm install -D @commitlint/cli @commitlint/config-conventional
+        run: npm install -D @commitlint/cli@${{ env.COMMITLINT_VERSION }} @commitlint/config-conventional@${{ env.COMMITLINT_VERSION }}
       - name: Print versions
         run: |
           git --version


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR pins the version of commitlint to 20.5.0.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
