### PR TITLE
feat(debugger): improve debugger logs

### DIFF
--- a/cmd/debugger/validate.go
+++ b/cmd/debugger/validate.go
@@ -22,30 +22,20 @@ const staticPodAnnotation = "kubernetes.io/config.mirror"
 
 type nodeName = string
 
-func printAgentCache(w io.Writer,
-	agentCachePerNode map[nodeName][]*agentv1.PodView) {
-	nodes := make([]string, 0, len(agentCachePerNode))
-	for n := range agentCachePerNode {
-		nodes = append(nodes, n)
-	}
-	sort.Strings(nodes)
-
-	fmt.Fprintln(w, "=== Agent Caches Dump ===")
-	// For each node
-	for _, node := range nodes {
-		cache := agentCachePerNode[node]
-		fmt.Fprintf(w, "\nNode: %s (%d pods)\n", node, len(cache))
-		for _, view := range cache {
-			fmt.Fprintf(
-				w,
-				"- pod: (%s/%s)-%s\n",
-				view.GetMeta().GetNamespace(),
-				view.GetMeta().GetName(),
-				view.GetMeta().GetId(),
-			)
-			for containerID, containerMeta := range view.GetContainers() {
-				fmt.Fprintf(w, "-- container: (id=%s) %s\n", containerID, containerMeta.GetName())
-			}
+func printNodeAgentCache(w io.Writer,
+	nodeName string,
+	nodeCache []*agentv1.PodView) {
+	fmt.Fprintf(w, "=== Node '%s' cache dump (%d pods) ===\n", nodeName, len(nodeCache))
+	for _, view := range nodeCache {
+		fmt.Fprintf(
+			w,
+			"- pod: (%s/%s)-%s\n",
+			view.GetMeta().GetNamespace(),
+			view.GetMeta().GetName(),
+			view.GetMeta().GetId(),
+		)
+		for containerID, containerMeta := range view.GetContainers() {
+			fmt.Fprintf(w, "-- container: (id=%s) %s\n", containerID, containerMeta.GetName())
 		}
 	}
 	fmt.Fprintln(w)
@@ -58,9 +48,13 @@ func validateAgentCache(w io.Writer,
 	hasDiff := false
 
 	if len(expectedCachePerNode) != len(agentCachePerNode) {
-		fmt.Fprintf(w, "- Mismatch on nodes number: expected %d nodes, got %d\n",
-			len(expectedCachePerNode), len(agentCachePerNode))
-		hasDiff = true
+		// This is possible for example when the runtime enforcer is not installed on some agents.
+		fmt.Fprintf(
+			w,
+			"- Some nodes in the cluster don't have an agent cache. Nodes in the cluster: %d, agent caches: %d.\n",
+			len(expectedCachePerNode),
+			len(agentCachePerNode),
+		)
 	}
 
 	// We are sure the number of nodes is the same
@@ -68,7 +62,7 @@ func validateAgentCache(w io.Writer,
 		// Skip nodes without an agent cache
 		actualPods, ok := agentCachePerNode[nodeName]
 		if !ok {
-			fmt.Fprintf(w, "- node %s: no agent cache available\n", nodeName)
+			fmt.Fprintf(w, "- node '%s': no agent cache available\n", nodeName)
 			continue
 		}
 
@@ -84,6 +78,8 @@ func validateAgentCache(w io.Writer,
 			fmt.Fprintf(w, "- cache on node '%s' is not aligned\n%s\n",
 				nodeName, diff)
 			hasDiff = true
+			// In case of diff, print the agent cache
+			printNodeAgentCache(w, nodeName, agentCachePerNode[nodeName])
 		}
 	}
 
@@ -91,8 +87,6 @@ func validateAgentCache(w io.Writer,
 		fmt.Fprintln(w, "caches are aligned")
 	} else {
 		fmt.Fprintln(w, "caches are not aligned")
-		// In case of diff, print the agent cache
-		printAgentCache(w, agentCachePerNode)
 	}
 }
 

--- a/cmd/debugger/validate_test.go
+++ b/cmd/debugger/validate_test.go
@@ -254,7 +254,7 @@ func TestValidateAgentCache(t *testing.T) {
 				nodeName1: {podA},
 				nodeName2: {podB},
 			},
-			expectedOutput: []string{"Mismatch on nodes number", "caches are not aligned"},
+			expectedOutput: []string{"Some nodes in the cluster don't have an agent cache", "caches are aligned"},
 		},
 		{
 			name: "pod mismatch",


### PR DESCRIPTION
**What this PR does / why we need it**:

In a cluster with a lot of pods and nodes, printing the whole cache content for a single diff could be too much. We now just print the cache of that node.
In our demo-dev cluster, we don't install the runtime enforcer on all nodes, so we print the full cache at each iteration...
```txt
- Mismatch on number of nodes: expected 9 nodes, got 4
```


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
