### PR TITLE
fix: increase memory resource limit

### DIFF
--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -25,10 +25,10 @@ controller:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
   wpStatusUpdateInterval: 30s
   # The podSecurityContext used by runtime-enforcer controller
   # @schema additionalProperties:true
@@ -154,10 +154,10 @@ debugger:
   resources:
     limits:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
     requests:
       cpu: 500m
-      memory: 128Mi
+      memory: 256Mi
 
 # Learning mode configuration
 learning:


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

In our testing we found that 128 mb is often not sufficient when there are many nodes/workloads.

This commit increases the default number to 256 mb, so it provides better out-of-box experience.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
