### PR TITLE
refactor: turn an error into an info log

### DIFF
--- a/api/v1alpha1/workloadpolicyproposal_test.go
+++ b/api/v1alpha1/workloadpolicyproposal_test.go
@@ -1,0 +1,131 @@
+package v1alpha1_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkloadPolicyProposalNamespacedName(t *testing.T) {
+	t.Run("nil proposal returns empty string", func(t *testing.T) {
+		var p *v1alpha1.WorkloadPolicyProposal
+		require.Empty(t, p.NamespacedName())
+	})
+
+	t.Run("returns namespace/name", func(t *testing.T) {
+		p := &v1alpha1.WorkloadPolicyProposal{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-namespace",
+				Name:      "test-name",
+			},
+		}
+		require.Equal(t, "test-namespace/test-name", p.NamespacedName())
+	})
+}
+
+func TestWorkloadPolicyProposalIsFull(t *testing.T) {
+	tests := []struct {
+		name           string
+		executables    int
+		expectedIsFull bool
+	}{
+		{
+			name:           "empty proposal is not full",
+			executables:    0,
+			expectedIsFull: false,
+		},
+		{
+			name:           "proposal below max is not full",
+			executables:    v1alpha1.PolicyProposalMaxExecutables - 1,
+			expectedIsFull: false,
+		},
+		{
+			name:           "proposal at max is full",
+			executables:    v1alpha1.PolicyProposalMaxExecutables,
+			expectedIsFull: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &v1alpha1.WorkloadPolicyProposal{}
+			for i := range tc.executables {
+				p.AddProcess("container", "/bin/exe"+strconv.Itoa(i))
+			}
+			require.Equal(t, tc.expectedIsFull, p.IsFull())
+		})
+	}
+}
+
+func TestWorkloadPolicyProposalAddProcess(t *testing.T) {
+	type addProcessCall struct {
+		containerName string
+		executable    string
+	}
+
+	tests := []struct {
+		name                        string
+		calls                       []addProcessCall
+		expectedContainers          int
+		expectedAllowedPerContainer map[string][]string
+	}{
+		{
+			name:               "adds executable to new container",
+			calls:              []addProcessCall{{"container1", "/bin/sh"}},
+			expectedContainers: 1,
+			expectedAllowedPerContainer: map[string][]string{
+				"container1": {"/bin/sh"},
+			},
+		},
+		{
+			name: "adds executable to existing container",
+			calls: []addProcessCall{
+				{"container1", "/bin/sh"},
+				{"container1", "/bin/bash"},
+			},
+			expectedContainers: 1,
+			expectedAllowedPerContainer: map[string][]string{
+				"container1": {"/bin/sh", "/bin/bash"},
+			},
+		},
+		{
+			name: "does not add duplicate executable",
+			calls: []addProcessCall{
+				{"container1", "/bin/sh"},
+				{"container1", "/bin/sh"},
+			},
+			expectedContainers: 1,
+			expectedAllowedPerContainer: map[string][]string{
+				"container1": {"/bin/sh"},
+			},
+		},
+		{
+			name: "handles multiple containers independently",
+			calls: []addProcessCall{
+				{"container1", "/bin/sh"},
+				{"container2", "/bin/bash"},
+			},
+			expectedContainers: 2,
+			expectedAllowedPerContainer: map[string][]string{
+				"container1": {"/bin/sh"},
+				"container2": {"/bin/bash"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &v1alpha1.WorkloadPolicyProposal{}
+			for _, call := range tc.calls {
+				p.AddProcess(call.containerName, call.executable)
+			}
+			require.Len(t, p.Spec.RulesByContainer, tc.expectedContainers)
+			for container, executables := range tc.expectedAllowedPerContainer {
+				require.ElementsMatch(t, executables, p.Spec.RulesByContainer[container].Executables.Allowed)
+			}
+		})
+	}
+}

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"errors"
 	"slices"
 
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
@@ -62,11 +61,18 @@ func (p *WorkloadPolicyProposal) getExecutablesLength() int {
 	return result
 }
 
-func (p *WorkloadPolicyProposal) AddProcess(containerName string, executable string) error {
-	if p.getExecutablesLength() >= PolicyProposalMaxExecutables {
-		return errors.New("the number of executables has exceeded its maximum")
+func (p *WorkloadPolicyProposal) NamespacedName() string {
+	if p == nil {
+		return ""
 	}
+	return p.Namespace + "/" + p.Name
+}
 
+func (p *WorkloadPolicyProposal) IsFull() bool {
+	return p.getExecutablesLength() >= PolicyProposalMaxExecutables
+}
+
+func (p *WorkloadPolicyProposal) AddProcess(containerName string, executable string) {
 	if p.Spec.RulesByContainer == nil {
 		p.Spec.RulesByContainer = make(map[string]*WorkloadPolicyRules)
 	}
@@ -78,16 +84,14 @@ func (p *WorkloadPolicyProposal) AddProcess(containerName string, executable str
 				Allowed: []string{executable},
 			},
 		}
-		return nil
+		return
 	}
 
 	if slices.Contains(rules.Executables.Allowed, executable) {
-		return nil
+		return
 	}
 
 	rules.Executables.Allowed = append(rules.Executables.Allowed, executable)
-
-	return nil
 }
 
 func (p *WorkloadPolicyProposal) AddPartialOwnerReferenceDetails(workloadKind string, workload string) {

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -287,10 +287,14 @@ func (r *LearningReconciler) reconcile(
 			return nil
 		}
 
-		if err = policyProposal.AddProcess(req.ContainerName, req.ExecutablePath); err != nil {
-			// unable to add a process to a policy proposal.  The policy proposal is likely full.
-			return reconcile.TerminalError(fmt.Errorf("failed to add process to policy proposal: %w", err))
+		if policyProposal.IsFull() {
+			logger.Info("proposal is full, cannot add new executables",
+				"proposal", policyProposal.NamespacedName(),
+				"exe", req.ExecutablePath,
+			)
+			return nil
 		}
+		policyProposal.AddProcess(req.ContainerName, req.ExecutablePath)
 
 		// If the owner reference is already there we do nothing.
 		// We should always have the owner reference populated unless we are creating the resource for the first time.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR turns an error into an info log. Ideally, we should use a warning, but this is not available with go-logr/logr.

**Which issue(s) this PR fixes**

fixes #566 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
