### PR TITLE
chore: switch debugger base image from alpine to SUSE BCI minimal

### DIFF
--- a/hack/Dockerfile.debugger.tilt
+++ b/hack/Dockerfile.debugger.tilt
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-minimal
+FROM registry.suse.com/bci/bci-base
 WORKDIR /
 COPY ./bin/debugger /debugger
 

--- a/hack/Dockerfile.debugger.tilt
+++ b/hack/Dockerfile.debugger.tilt
@@ -1,4 +1,4 @@
-FROM alpine
+FROM registry.suse.com/bci/bci-minimal
 WORKDIR /
 COPY ./bin/debugger /debugger
 

--- a/package/Dockerfile.debugger
+++ b/package/Dockerfile.debugger
@@ -14,8 +14,8 @@ COPY go.mod go.sum /src/
 COPY Makefile /src/
 RUN make debugger
 
-# We use alpine and not `scratch` since it provides a more complete environment.
-FROM alpine
+# We use bci-minimal and not `scratch` since it provides a more complete environment.
+FROM registry.suse.com/bci/bci-minimal
 WORKDIR /
 COPY --from=builder /src/bin/debugger /debugger
 


### PR DESCRIPTION

**What this PR does / why we need it**:

In order to make a security audit possible I'm doing what I can on our end to ensure compliance :-) and one of the things we need is switching to BCIs where we don't use `scratch` images.
