### PR TITLE
refactor: simplify redundant log

### DIFF
--- a/internal/bpf/cgtracker_test.go
+++ b/internal/bpf/cgtracker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/cgroups"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
@@ -26,7 +27,7 @@ func TestUpdateCgTrackerMap(t *testing.T) {
 	expectedMap := map[uint64]uint64{
 		cgroup1: cgroup1,
 	}
-	err = updateCgTrackerMap(newTestLogger(t), cgTrackerMap, cgroup1, "")
+	err = updateCgTrackerMap(testutil.NewTestLogger(t), cgTrackerMap, cgroup1, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedMap, dumpMap(cgTrackerMap))
 
@@ -64,7 +65,7 @@ func TestUpdateCgTrackerMap(t *testing.T) {
 		expectedNestedCgroup3: cgroup1,
 	}
 
-	err = updateCgTrackerMap(newTestLogger(t), cgTrackerMap, cgroup1, tempDir)
+	err = updateCgTrackerMap(testutil.NewTestLogger(t), cgTrackerMap, cgroup1, tempDir)
 	require.NoError(t, err)
 	require.Equal(t, expectedMap, dumpMap(cgTrackerMap))
 }

--- a/internal/bpf/runner_helper_test.go
+++ b/internal/bpf/runner_helper_test.go
@@ -10,29 +10,10 @@ import (
 	"time"
 
 	"github.com/rancher-sandbox/runtime-enforcer/internal/cgroups"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"golang.org/x/sync/errgroup"
 )
-
-//////////////////////
-// Test Logger
-//////////////////////
-
-type testLogWriter struct {
-	t *testing.T
-}
-
-func (w *testLogWriter) Write(p []byte) (int, error) {
-	// use the formatted output to avoid the new line
-	w.t.Logf("%s", string(p))
-	return len(p), nil
-}
-
-func newTestLogger(t *testing.T) *slog.Logger {
-	return slog.New(slog.NewJSONHandler(&testLogWriter{t: t}, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	})).With("component", "bpftest")
-}
 
 //////////////////////
 // Channel helpers
@@ -246,5 +227,5 @@ func newCgroupRunnerWithLogger(t *testing.T, logger *slog.Logger) (*cgroupRunner
 }
 
 func newCgroupRunner(t *testing.T) (*cgroupRunner, error) {
-	return newCgroupRunnerWithLogger(t, newTestLogger(t))
+	return newCgroupRunnerWithLogger(t, testutil.NewTestLogger(t))
 }

--- a/internal/bpf/verifier_test.go
+++ b/internal/bpf/verifier_test.go
@@ -2,6 +2,8 @@ package bpf
 
 import (
 	"testing"
+
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 )
 
 // run it with: go test -v -run TestNoVerifierFailures ./internal/bpf -count=1 -exec "sudo -E".
@@ -18,7 +20,7 @@ func TestNoVerifierFailures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Loading happens here so we can catch verifier errors without running the manager
-			_, err := NewManager(newTestLogger(t), tt.enableLearning)
+			_, err := NewManager(testutil.NewTestLogger(t), tt.enableLearning)
 			if err == nil {
 				t.Log("BPF manager started successfully :)!!")
 				return

--- a/internal/controller/workloadpolicystatus_test.go
+++ b/internal/controller/workloadpolicystatus_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/grpcexporter"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 	"github.com/stretchr/testify/require"
@@ -19,16 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
-
-type testLogWriter struct {
-	t *testing.T
-}
-
-func (w *testLogWriter) Write(p []byte) (int, error) {
-	// use the formatted output to avoid the new line
-	w.t.Logf("%s", string(p))
-	return len(p), nil
-}
 
 func createTestWPStatusSync(t *testing.T) *WorkloadPolicyStatusSync {
 	scheme := runtime.NewScheme()
@@ -44,9 +34,7 @@ func createTestWPStatusSync(t *testing.T) *WorkloadPolicyStatusSync {
 			LabelSelectorString: "app=agent",
 			// We explicitly provide a namespace so that this is not computed at runtime.
 			Namespace: "test-namespace",
-			Logger: slog.New(slog.NewJSONHandler(&testLogWriter{t: t}, &slog.HandlerOptions{
-				Level: slog.LevelDebug,
-			})).With("component", "agent-pool"),
+			Logger:    testutil.NewTestLogger(t),
 		},
 		UpdateInterval: 1 * time.Second,
 	}

--- a/internal/nri/plugin.go
+++ b/internal/nri/plugin.go
@@ -191,9 +191,7 @@ func (p *plugin) StartContainer(
 			return nil
 		}
 		nriErr := fmt.Errorf(
-			"%s: %w. Runtime-enforcer has prevented the container '%s/%s' from starting. To change this behavior, set agent.nriFailopen=true in the helm chart",
-			reason,
-			err,
+			"runtime-enforcer has prevented the container '%s/%s' from starting. To change this behavior, set agent.nriFailopen=true in the helm chart",
 			pod.GetName(),
 			container.GetName(),
 		)

--- a/internal/nri/plugin_test.go
+++ b/internal/nri/plugin_test.go
@@ -2,12 +2,11 @@ package nri
 
 import (
 	"errors"
-	"io"
-	"log/slog"
 	"testing"
 
 	"github.com/containerd/nri/pkg/api"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/resolver"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/workloadkind"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func newTestPlugin(
 	t.Helper()
 
 	return &plugin{
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:   testutil.NewTestLogger(t),
 		resolver: resolver.NewTestResolver(t),
 		failOpen: failOpen,
 		resolveCgroupID: func(*api.Container) (resolver.CgroupID, string, error) {
@@ -100,8 +99,7 @@ func TestPluginStartContainer(t *testing.T) {
 
 		err := p.StartContainer(t.Context(), pod, container)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "failed to get cgroup ID from container: lookup failed")
-		require.ErrorContains(t, err, "Runtime-enforcer has prevented the container 'demo-pod/app' from starting")
+		require.ErrorContains(t, err, "runtime-enforcer has prevented the container 'demo-pod/app' from starting")
 		require.Empty(t, p.resolver.PodCacheSnapshot())
 	})
 }

--- a/internal/testutil/logger.go
+++ b/internal/testutil/logger.go
@@ -1,0 +1,22 @@
+package testutil
+
+import (
+	"log/slog"
+	"testing"
+)
+
+type testLogWriter struct {
+	t *testing.T
+}
+
+func (w *testLogWriter) Write(p []byte) (int, error) {
+	w.t.Logf("%s", string(p))
+	return len(p), nil
+}
+
+// NewTestLogger returns an [slog.Logger] that writes to t.Logf.
+func NewTestLogger(t *testing.T) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(&testLogWriter{t: t}, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})).With("component", t.Name())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Today, when a pod fails with failClose we receive this error 
```json
{"time":"2026-04-20T12:20:07.48504881Z","level":"ERROR","msg":"failed to get cgroup ID from container: failed to get cgroup ID from path '/proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope' for container 'ubuntu(d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f)': nameToHandle on /proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope failed: no such file or directory. Runtime-enforcer has prevented the container 'ubuntu-deployment-gvisor-648bcf55f8-qptbl/ubuntu' from starting. To change this behavior, set agent.nriFailopen=true in the helm chart","component":"agent","component":"nri-handler","component":"nri-plugin","pod":{"name":"ubuntu-deployment-gvisor-648bcf55f8-qptbl","namespace":"default","uid":"bd1bc160-884d-4e26-9a29-57497e462d5e"},"container":{"name":"ubuntu","id":"d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f"},"reason":"failed to get cgroup ID from container","error":"failed to get cgroup ID from path '/proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope' for container 'ubuntu(d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f)': nameToHandle on /proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope failed: no such file or directory"}
```

The reason and the error are printed twice...Causing a very verbose error
After this PR

```json
{"time":"2026-04-20T12:20:07.48504881Z","level":"ERROR","msg":"runtime-enforcer has prevented the container 'ubuntu-deployment-gvisor-648bcf55f8-qptbl/ubuntu' from starting. To change this behavior, set agent.nriFailopen=true in the helm chart","component":"agent","component":"nri-handler","component":"nri-plugin","pod":{"name":"ubuntu-deployment-gvisor-648bcf55f8-qptbl","namespace":"default","uid":"bd1bc160-884d-4e26-9a29-57497e462d5e"},"container":{"name":"ubuntu","id":"d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f"},"reason":"failed to get cgroup ID from container","error":"failed to get cgroup ID from path '/proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope' for container 'ubuntu(d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f)': nameToHandle on /proc/1/root/sys/fs/cgroup/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podbd1bc160_884d_4e26_9a29_57497e462d5e.slice/cri-containerd-d1fd62180601515f848608770e9b434073727ff28eda1d64efbe1dfa943d598f.scope failed: no such file or directory"}
```


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
