### PR TITLE
docs: nri timeout & required plugins

### DIFF
--- a/docs/troubleshooting.adoc
+++ b/docs/troubleshooting.adoc
@@ -46,7 +46,22 @@ If there is a discrepancy you will see a diff with the affected node and pods, f
 == NRI timeouts and required plugins
 
 Runtime Enforcer relies on NRI (Node Resource Interface) integration provided by the container runtime.
-Some environments may hit the NRI default request timeout (default is `2s`), which can cause the NRI plugin to be detached from the container runtime. This can cause the agent to repeatedly retry connecting to the NRI plugin, resulting in the agent not coming up as expected.
+
+Some environments may hit the NRI default request timeout (`5s` to register a plugin and `2s` to handle an event), which can cause the NRI plugin to be detached from the container runtime. This can cause the agent to repeatedly retry connecting to the NRI plugin, resulting in the agent not coming up as expected.
+
+When this happens, you would see runtime-enforcer agent crashing with the following information in its logs:
+
+----
+{"time":"2026-04-24T15:36:07.617127725Z","level":"INFO","msg":"ttrpc server closed 00-runtime-enforcer-agent : ttrpc: server closed","component":"agent","component":"nri-handler","component":"nri-stub"}
+----
+
+You will also see logs like the following in containerd's logs, indicating that the configured timeout value was exceeded:
+
+----
+Apr 24 15:36:27 kind-control-plane containerd[114]: time="2026-04-24T15:36:27.664534740Z" level=info msg="connection to plugin \"00-runtime-enforcer-agent\" closed"
+Apr 24 15:36:27 kind-control-plane containerd[114]: time="2026-04-24T15:36:27.664575617Z" level=info msg="failed to synchronize plugin: context deadline exceeded"
+Apr 24 15:39:38 kind-control-plane containerd[114]: time="2026-04-24T15:39:38.782163498Z" level=error msg="closing plugin 00-runtime-enforcer-agent, failed to handle event 6: context deadline exceeded"
+----
 
 To mitigate this, you can increase the NRI timeout on the container runtime side by editing the container runtime configuration file.
 
@@ -54,13 +69,15 @@ To mitigate this, you can increase the NRI timeout on the container runtime side
 
 Edit `/etc/containerd/config.toml` and update the NRI plugin timeouts under `[plugins."io.containerd.nri.v1.nri"]`:
 
+The example below changes the settings to `10s` and `5s`.
+
 [source,toml]
 ----
 [plugins."io.containerd.nri.v1.nri"]
   # plugin_registration_timeout is the timeout for a plugin to register after connection.
-  plugin_registration_timeout = "5s"
+  plugin_registration_timeout = "10s"
   # plugin_request_timeout is the timeout for a plugin to handle an event/request.
-  plugin_request_timeout = "2s"
+  plugin_request_timeout = "5s"
 ----
 
 For details and additional NRI settings, see https://github.com/containerd/containerd/blob/main/docs/NRI.md#disabling-nri-support-in-containerd[containerd NRI configuration documentation].
@@ -69,13 +86,15 @@ For details and additional NRI settings, see https://github.com/containerd/conta
 
 Edit `/etc/crio/crio.conf` and update the `crio.nri` table:
 
+The example below changes the setting to `10s` and `5s`.
+
 [source,toml]
 ----
 [crio.nri]
   # Timeout for a plugin to register itself with NRI.
-  nri_plugin_registration_timeout = "5s"
+  nri_plugin_registration_timeout = "10s"
   # Timeout for a plugin to handle an NRI request.
-  nri_plugin_request_timeout = "2s"
+  nri_plugin_request_timeout = "5s"
 ----
 
 For details, see https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionri-table[CRI-O NRI configuration documentation].
@@ -84,38 +103,70 @@ For details, see https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#cr
 
 Additionally, recent container runtimes provide an option to require a set of NRI plugins to always be present for container creation to succeed.
 
-WARNING: When this is enabled and the required NRI plugin is not present on a node, the container runtime will reject container creation/start requests.
+Follow the steps below to configure this on a per-workload basis. Check https://github.com/containerd/nri/blob/57442b2a20c63d48d69dc600c3fb4f0c063c7ef0/docs/validation-plugins.md#dealing-with-required-plugins[NRI docs] for more information about the best option to suit your environment.
+
+==== Prerequisites
+
+The *required plugins* feature is available since *containerd 2.2* and *CRI-O 1.34.0*.
+
+==== Workloads
+
+For workloads that you want to ensure have runtime-enforcer protection present, add the `required-plugins.noderesource.dev` annotation to its pod spec:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ubuntu-deployment
+  labels:
+    app: ubuntu
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ubuntu
+  template:
+    metadata:
+      labels:
+        app: ubuntu
+        security.rancher.io/policy: workloadpolicy-sample
+      annotations:
+        # This specifies "runtime-enforcer-agent" plugin to be required.
+        required-plugins.noderesource.dev: '["runtime-enforcer-agent"]'
+    spec:
+      containers:
+      - name: ubuntu
+        image: ubuntu
+        stdin: true
+        tty: true
+----
+
+When the required plugin is not available for any reason, the workload will fail to start with errors in Kubernetes events:
+
+----
+4s          Warning   Failed                    pod/ubuntu-deployment-6655f5c7ff-xghnd    Error: failed to create containerd container: failed to get NRI adjustment for container: validator "00-default-validator" rejected container adjustment, reason: validation error: required plugin "runtime-enforcer-agent" not present
+----
 
 ==== containerd: required_plugins
 
-In `/etc/containerd/config.toml`, configure the `default_validator`:
+In `/etc/containerd/config.toml`, enable the `default_validator`:
 
 [source,toml]
 ----
 [plugins."io.containerd.nri.v1.nri".default_validator]
   enable = true
-  required_plugins = [ <list of required NRI plugins> ]
 ----
-
-Replace `"<list of required NRI plugins>"` with our plugin name `runtime-enforcer-agent` as registered with NRI in your environment.
-See https://github.com/containerd/containerd/blob/main/docs/NRI.md#default-validator[containerd NRI configuration documentation] for more details.
 
 ==== CRI-O: nri_validator_required_plugins
 
-In `/etc/crio/crio.conf`, configure the `crio.nri.default_validator` table:
+In `/etc/crio/crio.conf`, configure the `crio.nri.default_validator` table to enable the default validator:
 
 [source,toml]
 ----
 [crio.nri.default_validator]
   nri_enable_default_validator = true
-  # List of required NRI plugins that must be present.
-  nri_validator_required_plugins = ["<list of required NRI plugins>"]
 ----
-
-Replace `"<list of required NRI plugins>"` with our plugin name `runtime-enforcer-agent` as registered with NRI in your environment.
-See https://github.com/cri-o/cri-o/blob/main/docs/crio.conf.5.md#crionridefault_validator-table[CRI-O NRI configuration documentation] for more details.
-
-NOTE: The *required plugins* feature is available since *containerd 2.2* and *CRI-O 1.34.0*.
 
 === Enabling the debugger
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR updates the troubleshooting docs:

1. Provide more error logs for users to reference in NRI timeout scenario.
2. Update the example to have higher values.
3. Replace the document about `required_plugins` with `required-plugins.noderesource.dev`.  This change comes with a few benefits:
    - This will not affect static pods and runtime-enforcer unless users add the annotations.
    - More flexibility over this option, e.g., they can add the annotations from a mutating admission controller. 

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
