### PR TITLE
fix: add default selinux options

### DIFF
--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -112,6 +112,15 @@
                         "runAsNonRoot": {
                             "type": "boolean"
                         },
+                        "seLinuxOptions": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false
+                        },
                         "seccompProfile": {
                             "type": "object",
                             "properties": {

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -112,6 +112,9 @@ agent:
     # this is required for us the access the cgroup setting on the host
     appArmorProfile:
       type: Unconfined
+    # this is required for us the access the cgroup setting on the host with SELinux enabled
+    seLinuxOptions:
+      type: spc_t
   serviceAccount:
     # agent.serviceAccount.annotations -- Additional annotations to add to agent's service account.
     # @schema additionalProperties:true


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Add a default SELinux options so agent can access cgroup on SELinux-enabled system.

**Which issue(s) this PR fixes**

fixes #583

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
