### PR TITLE
feat: adding github actions for running e2e tests

### DIFF
--- a/.github/workflows/oracle-linux-10-e2e.yml
+++ b/.github/workflows/oracle-linux-10-e2e.yml
@@ -1,0 +1,22 @@
+name: oracle-linux-10-e2e
+on:
+ release:
+   types: published
+ schedule:
+   - cron: "15 0 * * 5"
+     timezone: "America/New_York"
+ workflow_dispatch:
+jobs:
+  run-e2e-test:
+    permissions:
+      contents: read
+    name: Run e2e test on Oracle 10.1
+    runs-on: oracle
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Run e2e test
+      run: |
+        go clean -testcache
+        E2E_USE_EXISTING_CLUSTER=true E2E_SKIP_DEPENDENCIES= go test -v -timeout 20m ./test/e2e/

--- a/.github/workflows/redhat-linux-10-e2e.yml
+++ b/.github/workflows/redhat-linux-10-e2e.yml
@@ -1,0 +1,22 @@
+name: redhat-linux-10-e2e
+on:
+ release:
+   types: published
+ schedule:
+   - cron: "15 0 * * 5"
+     timezone: "America/New_York"
+ workflow_dispatch:
+jobs:
+  run-e2e-test:
+    permissions:
+      contents: read
+    name: Run e2e test on RHEL 10.2
+    runs-on: redhat
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Run e2e test
+      run: |
+        go clean -testcache
+        E2E_USE_EXISTING_CLUSTER=true E2E_SKIP_DEPENDENCIES= go test -v -timeout 20m ./test/e2e/

--- a/.github/workflows/suse-linux-16-e2e.yml
+++ b/.github/workflows/suse-linux-16-e2e.yml
@@ -1,0 +1,22 @@
+name: suse-linux-16-e2e
+on:
+ release:
+   types: published
+ schedule:
+   - cron: "15 0 * * 5"
+     timezone: "America/New_York"
+ workflow_dispatch:
+jobs:
+  run-e2e-test:
+    permissions:
+      contents: read
+    name: Run e2e test on SLES 16
+    runs-on: suse
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Run e2e test
+      run: |
+        go clean -testcache
+        E2E_USE_EXISTING_CLUSTER=true E2E_SKIP_DEPENDENCIES= go test -v -timeout 20m ./test/e2e/


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
-->

**What this PR does / why we need it**:

Adding e2e tests which would run at 12:15 AM on Fridays, on demand and on every release.
e2e tests will run on below OS (three different jobs)

- SUSE Linux Enterprise Server 16.0
- Red Hat Enterprise Linux 10.2 Beta (Coughlan)
- Oracle Linux Server 10.1

**Which issue(s) this PR fixes**

fixes #432 

**Special notes for your reviewer**:
Need to add self hosted machines to this repo.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
