### PR TITLE
refactor: helm unit-test

### DIFF
--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -16,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-      {{- include "runtime-enforcer.agent.labelSelector" . | nindent 8 }}
+        {{- include "runtime-enforcer.labels" . | nindent 8 }}
+        app.kubernetes.io/component: agent
       {{- with .Values.agent.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -85,8 +85,7 @@ spec:
         {{- with .Values.agent.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}
         imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         name: agent
         startupProbe:

--- a/charts/runtime-enforcer/templates/controller/deployment.yaml
+++ b/charts/runtime-enforcer/templates/controller/deployment.yaml
@@ -14,8 +14,8 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "runtime-enforcer.labels" . | nindent 8 }}
         app.kubernetes.io/component: controller
-      {{- include "runtime-enforcer.selectorLabels" . | nindent 8 }}
       {{- with .Values.controller.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/runtime-enforcer/templates/controller/deployment.yaml
+++ b/charts/runtime-enforcer/templates/controller/deployment.yaml
@@ -48,8 +48,7 @@ spec:
         {{- with .Values.controller.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         livenessProbe:
           httpGet:

--- a/charts/runtime-enforcer/templates/debugger/deployment.yaml
+++ b/charts/runtime-enforcer/templates/debugger/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "runtime-enforcer.fullname" . }}-debugger
+      securityContext: {{- toYaml .Values.debugger.podSecurityContext | nindent 8 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 8 }}

--- a/charts/runtime-enforcer/templates/debugger/deployment.yaml
+++ b/charts/runtime-enforcer/templates/debugger/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "runtime-enforcer.fullname" . }}-debugger
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: debugger
         image: {{ .Values.debugger.image.repository }}:{{ .Values.debugger.image.tag }}
@@ -40,6 +44,9 @@ spec:
           value: {{ include "runtime-enforcer.agent.labelSelectorString" . | quote }}
         - name: DEBUGGER_CERT_DIR
           value: {{ include "runtime-enforcer.grpc.certDir" . | quote }}
+        {{- with .Values.debugger.env }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- with .Values.debugger.resources }}
         resources:
         {{- toYaml . | nindent 10 }}
@@ -49,9 +56,17 @@ spec:
           mountPath: {{ include "runtime-enforcer.grpc.certDir" . }}
           readOnly: true
         securityContext: {{- toYaml .Values.debugger.containerSecurityContext | nindent 10 }}
+      {{- with .Values.debugger.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.debugger.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.debugger.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       - name: grpc-certs

--- a/charts/runtime-enforcer/tests/common_test.yaml
+++ b/charts/runtime-enforcer/tests/common_test.yaml
@@ -1,0 +1,119 @@
+suite: "Verify Common Configurations"
+templates:
+  - templates/agent/daemonset.yaml
+  - templates/controller/deployment.yaml
+  - templates/debugger/deployment.yaml
+chart:
+  version: 1.0.0
+  appVersion: 2.0.0
+release:
+  name: my-release
+  namespace: my-namespace
+set:
+  #priorityClass: # debugger doesn't support priority class
+  #  name: priorityclass
+  imagePullSecrets:
+    - name: pullSecret
+
+sharedValues: &sharedValues
+  image:
+    repository: somewhere/component
+    tag: v9.9.9
+    pullPolicy: Always
+  tolerations:
+    - key: "dedicated"
+      operator: "Equal"
+      value: "experimental"
+      effect: "NoSchedule"
+  # logLevel: debug # Not supported by debugger
+  env:
+    - name: EXTRA_ENV
+      value: extra_value
+  podLabels:
+    environment: staging
+    team: platform
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+  nodeSelector:
+    kubernetes.io/os: linux
+    node-role: control-plane
+    disk: ssd
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                  - amd64
+
+sharedAsserts: &sharedAsserts
+  - equal:
+      path: "spec.template.spec.containers[0].image"
+      value: "somewhere/component:v9.9.9"
+  - equal:
+      path: "spec.template.spec.containers[0].imagePullPolicy"
+      value: "Always"
+  - contains:
+      path: spec.template.spec.tolerations
+      content:
+        key: "dedicated"
+        operator: "Equal"
+        value: "experimental"
+        effect: "NoSchedule"
+  - contains:
+      path: "spec.template.spec.containers[0].env"
+      content:
+        name: EXTRA_ENV
+        value: extra_value
+  - equal:
+      path: spec.template.metadata.labels["environment"]
+      value: staging
+  - equal:
+      path: spec.template.metadata.labels["team"]
+      value: platform
+  - equal:
+      path: spec.template.metadata.annotations["prometheus.io/scrape"]
+      value: "true"
+  - equal:
+      path: spec.template.metadata.annotations["prometheus.io/port"]
+      value: "9090"
+  - equal:
+      path: spec.template.spec.nodeSelector["kubernetes.io/os"]
+      value: linux
+  - equal:
+      path: spec.template.spec.nodeSelector["node-role"]
+      value: control-plane
+  - equal:
+      path: spec.template.spec.nodeSelector["disk"]
+      value: ssd
+  - equal:
+      path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+      value: kubernetes.io/arch
+  - contains:
+      path: "spec.template.spec.imagePullSecrets"
+      content:
+        name: pullSecret
+
+tests:
+  - it: "should support all common flags in agent"
+    template: "templates/agent/daemonset.yaml"
+    set:
+      agent:
+        <<: *sharedValues
+    asserts: *sharedAsserts
+  - it: "should support all common flags in controller"
+    template: "templates/controller/deployment.yaml"
+    set:
+      controller:
+        <<: *sharedValues
+    asserts: *sharedAsserts
+  - it: "should support all common flags in debugger"
+    template: "templates/debugger/deployment.yaml"
+    set:
+      debugger:
+        <<: *sharedValues
+        enabled: true
+    asserts: *sharedAsserts

--- a/charts/runtime-enforcer/tests/common_test.yaml
+++ b/charts/runtime-enforcer/tests/common_test.yaml
@@ -48,6 +48,22 @@ sharedValues: &sharedValues
                 operator: In
                 values:
                   - amd64
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 123
+    seccompProfile:
+      type: seccompType
+    appArmorProfile:
+      type: appArmorType
+    seLinuxOptions:
+      type: seLinuxType
+  resources:
+    limits:
+      cpu: 111m
+      memory: 222Mi
+    requests:
+      cpu: 55m
+      memory: 111Mi
 
 sharedAsserts: &sharedAsserts
   - equal:
@@ -96,6 +112,26 @@ sharedAsserts: &sharedAsserts
       path: "spec.template.spec.imagePullSecrets"
       content:
         name: pullSecret
+  - equal:
+      path: spec.template.spec.securityContext
+      value:
+        runAsNonRoot: true
+        runAsUser: 123
+        seccompProfile:
+          type: seccompType
+        appArmorProfile:
+          type: appArmorType
+        seLinuxOptions:
+          type: seLinuxType
+  - equal:
+      path: spec.template.spec.containers[0].resources
+      value:
+        limits:
+          cpu: 111m
+          memory: 222Mi
+        requests:
+          cpu: 55m
+          memory: 111Mi
 
 tests:
   - it: "should support all common flags in agent"

--- a/charts/runtime-enforcer/tests/daemonset_test.yaml
+++ b/charts/runtime-enforcer/tests/daemonset_test.yaml
@@ -38,8 +38,7 @@ tests:
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].args"
-          content: "--learning-namespace-selector={\"matchExpressions\":[{\"key\":\"kuber\
-            netes.io/metadata.name\",\"operator\":\"Exists\"}]}"
+          content: '--learning-namespace-selector={"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"Exists"}]}'
 
   - it: "should render a custom learning namespace selector"
     set:

--- a/charts/runtime-enforcer/tests/daemonset_test.yaml
+++ b/charts/runtime-enforcer/tests/daemonset_test.yaml
@@ -3,20 +3,17 @@ templates:
   - "templates/agent/daemonset.yaml"
 
 tests:
-  - it: "should allow image, and imagePullPolicy to be overridden"
-    set:
-      agent:
-        image:
-          repository: somewhere/agent
-          tag: v9.9.9
-          pullPolicy: Always
+  - it: "should render component and default container"
     asserts:
       - equal:
-          path: "spec.template.spec.containers[0].image"
-          value: "somewhere/agent:v9.9.9"
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: "agent"
       - equal:
-          path: "spec.template.spec.containers[0].imagePullPolicy"
-          value: "Always"
+          path: spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"]
+          value: "agent"
+
+  - it: "should render default priority class name"
+    asserts:
       - equal:
           path: "spec.template.spec.priorityClassName"
           value: "runtime-enforcer-priorityclass"
@@ -30,7 +27,8 @@ tests:
     asserts:
       - notContains:
           path: "spec.template.spec.containers[0].args"
-          content: '--learning-namespace-selector={"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"Exists"}]}'
+          content: "--learning-namespace-selector={\"matchExpressions\":[{\"key\":\"kuber\
+            netes.io/metadata.name\",\"operator\":\"Exists\"}]}"
 
   - it: "should include default selector"
     set:
@@ -40,7 +38,8 @@ tests:
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].args"
-          content: '--learning-namespace-selector={"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"Exists"}]}'
+          content: "--learning-namespace-selector={\"matchExpressions\":[{\"key\":\"kuber\
+            netes.io/metadata.name\",\"operator\":\"Exists\"}]}"
 
   - it: "should render a custom learning namespace selector"
     set:
@@ -52,7 +51,7 @@ tests:
     asserts:
       - contains:
           path: "spec.template.spec.containers[0].args"
-          content: '--learning-namespace-selector={"matchLabels":{"env":"prod"}}'
+          content: "--learning-namespace-selector={\"matchLabels\":{\"env\":\"prod\"}}"
 
   - it: "should include grpc port argument"
     set:
@@ -63,23 +62,6 @@ tests:
           path: "spec.template.spec.containers[0].args"
           content: "--grpc-port=12"
 
-  - it: "check tolerations"
-    set:
-      agent:
-        tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "experimental"
-            effect: "NoSchedule"
-    asserts:
-      - contains:
-          path: spec.template.spec.tolerations
-          content:
-            key: "dedicated"
-            operator: "Equal"
-            value: "experimental"
-            effect: "NoSchedule"
-
   - it: "should include log level argument"
     set:
       agent:
@@ -89,95 +71,8 @@ tests:
           path: "spec.template.spec.containers[0].args"
           content: "--log-level=debug"
 
-  - it: "should add extra pod environment variables"
-    set:
-      agent:
-        env:
-          - name: EXTRA_ENV
-            value: extra_value
-    asserts:
-      - contains:
-          path: "spec.template.spec.containers[0].env"
-          content:
-            name: EXTRA_ENV
-            value: extra_value
-
-  - it: "should add extra pod labels"
-    set:
-      agent:
-        podLabels:
-          environment: staging
-          team: platform
-    asserts:
-      - equal:
-          path: spec.template.metadata.labels.environment
-          value: staging
-      - equal:
-          path: spec.template.metadata.labels.team
-          value: platform
-
-  - it: "should add extra pod annotations"
-    set:
-      agent:
-        podAnnotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "9090"
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations["prometheus.io/scrape"]
-          value: "true"
-      - equal:
-          path: spec.template.metadata.annotations["prometheus.io/port"]
-          value: "9090"
-
-  - it: "should set nodeSelector"
-    set:
-      agent:
-        nodeSelector:
-          kubernetes.io/os: linux
-          disk: ssd
-    asserts:
-      - equal:
-          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
-          value: linux
-      - equal:
-          path: spec.template.spec.nodeSelector.disk
-          value: ssd
-
-  - it: "should not render nodeSelector when empty"
-    set:
-      agent:
-        nodeSelector: {}
-    asserts:
-      - notExists:
-          path: spec.template.spec.nodeSelector
-
-  - it: "should set affinity"
-    set:
-      agent:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: kubernetes.io/arch
-                      operator: In
-                      values:
-                        - amd64
-    asserts:
-      - equal:
-          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
-          value: kubernetes.io/arch
-
-  - it: "should not render affinity when empty"
-    set:
-      agent:
-        affinity: {}
-    asserts:
-      - notExists:
-          path: spec.template.spec.affinity
-
-  - it: "should set OTEL env vars to built-in collector when collectorStrategy is default"
+  - it: "should set OTEL env vars to built-in collector when collectorStrategy is
+      default"
     set:
       telemetry:
         collectorStrategy: default
@@ -186,14 +81,16 @@ tests:
           path: "spec.template.spec.containers[0].env"
           content:
             name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: "https://RELEASE-NAME-runtime-enforcer-otel-collector.NAMESPACE.svc.cluster.local:4317"
+            value: "https://RELEASE-NAME-runtime-enforcer-otel-collector.NAMESPACE.svc.clus\
+              ter.local:4317"
       - contains:
           path: "spec.template.spec.containers[0].env"
           content:
             name: OTEL_EXPORTER_OTLP_CERTIFICATE
             value: "/etc/runtime-enforcer/certs/ca.crt"
 
-  - it: "should set OTEL env vars to external endpoint with insecure when no CA cert"
+  - it: "should set OTEL env vars to external endpoint with insecure when no CA
+      cert"
     set:
       telemetry:
         collectorStrategy: external

--- a/charts/runtime-enforcer/tests/default_test.yaml
+++ b/charts/runtime-enforcer/tests/default_test.yaml
@@ -1,0 +1,50 @@
+suite: "Verify Default Configurations"
+templates:
+  - templates/agent/daemonset.yaml
+  - templates/controller/deployment.yaml
+  - templates/debugger/deployment.yaml
+chart:
+  version: 1.0.0
+  appVersion: 2.0.0
+release:
+  name: my-release
+  namespace: my-namespace
+
+sharedAsserts: &sharedAsserts
+  - notExists:
+      path: spec.template.spec.tolerations
+  - notExists:
+      path: spec.template.spec.nodeSelector
+  - notExists:
+      path: spec.template.spec.affinity
+  - notExists:
+      path: "spec.template.spec.imagePullSecrets"
+  - equal:
+      path: spec.template.metadata.labels["app.kubernetes.io/name"]
+      value: "runtime-enforcer"
+  - equal:
+      path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+      value: "my-release"
+  - equal:
+      path: spec.template.metadata.labels["helm.sh/chart"]
+      value: "runtime-enforcer-1.0.0"
+  - equal:
+      path: spec.template.metadata.labels["app.kubernetes.io/managed-by"]
+      value: "Helm"
+  - equal:
+      path: spec.template.metadata.labels["app.kubernetes.io/version"]
+      value: "2.0.0"
+
+tests:
+  - it: "should render default fields when configs are absent in agent"
+    template: "templates/agent/daemonset.yaml"
+    asserts: *sharedAsserts
+  - it: "should render default fields when configs are absent in controller"
+    template: "templates/controller/deployment.yaml"
+    asserts: *sharedAsserts
+  - it: "should render default fields when configs are absent in debugger"
+    template: "templates/debugger/deployment.yaml"
+    set:
+      debugger:
+        enabled: true
+    asserts: *sharedAsserts

--- a/charts/runtime-enforcer/tests/deployment_debugger_test.yaml
+++ b/charts/runtime-enforcer/tests/deployment_debugger_test.yaml
@@ -1,66 +1,15 @@
 suite: "Debugger Deployment Tests"
 templates:
   - "templates/debugger/deployment.yaml"
-chart:
-  version: 1.0.0
-  appVersion: 2.0.0
-release:
-  name: my-release
-  namespace: my-namespace
 tests:
-  - it: "should set nodeSelector"
-    set:
-      debugger:
-        enabled: true
-        nodeSelector:
-          kubernetes.io/os: linux
-          node-role: control-plane
-    asserts:
-      - equal:
-          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
-          value: linux
-      - equal:
-          path: spec.template.spec.nodeSelector["node-role"]
-          value: control-plane
-
-  - it: "should not render nodeSelector when empty"
-    set:
-      debugger:
-        nodeSelector: {}
-    asserts:
-      - notExists:
-          path: spec.template.spec.nodeSelector
-  - it: "should set podLabels and podAnnotations"
-    set:
-      debugger:
-        enabled: true
-        podLabels:
-          label: label
-        podAnnotations:
-          annotation: annotation
-    asserts:
-      - equal:
-          path: spec.template.metadata.labels["label"]
-          value: label
-      - equal:
-          path: spec.template.metadata.annotations["annotation"]
-          value: annotation
-
-  - it: "should not render custom podLabels and podAnnotations when empty"
+  - it: "should render component and default container"
     set:
       debugger:
         enabled: true
     asserts:
       - equal:
-          path: spec.template.metadata.labels
-          value:
-            "helm.sh/chart": "runtime-enforcer-1.0.0"
-            "app.kubernetes.io/managed-by": "Helm"
-            "app.kubernetes.io/version": "2.0.0"
-            "app.kubernetes.io/component": "debugger"
-            "app.kubernetes.io/name": "runtime-enforcer"
-            "app.kubernetes.io/instance": "my-release"
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: "debugger"
       - equal:
-          path: spec.template.metadata.annotations
-          value:
-            "kubectl.kubernetes.io/default-container": "debugger"
+          path: spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"]
+          value: "debugger"

--- a/charts/runtime-enforcer/tests/deployment_test.yaml
+++ b/charts/runtime-enforcer/tests/deployment_test.yaml
@@ -3,24 +3,29 @@ templates:
   - "templates/controller/deployment.yaml"
 
 tests:
-  - it: "should allow image, and imagePullPolicy to be overridden"
+  - it: "should render component and default container"
+    set:
+      debugger:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: "controller"
+      - equal:
+          path: spec.template.metadata.annotations["kubectl.kubernetes.io/default-container"]
+          value: "manager"
+
+  - it: "should allow replicas to be overridden"
     set:
       controller:
         replicas: 5
-        image:
-          repository: somewhere/controller
-          tag: v9.9.9
-          pullPolicy: Always
     asserts:
       - equal:
           path: "spec.replicas"
           value: 5
-      - equal:
-          path: "spec.template.spec.containers[0].image"
-          value: "somewhere/controller:v9.9.9"
-      - equal:
-          path: "spec.template.spec.containers[0].imagePullPolicy"
-          value: "Always"
+
+  - it: "should render default priority class name"
+    asserts:
       - equal:
           path: "spec.template.spec.priorityClassName"
           value: "runtime-enforcer-priorityclass"
@@ -47,107 +52,6 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--wp-status-reconciler-agent-label-selector=app.kubernetes.io/component=agent,app.kubernetes.io/instance=RELEASE-NAME,app.kubernetes.io/name=runtime-enforcer"
-
-  - it: "check tolerations"
-    set:
-      controller:
-        tolerations:
-          - key: "dedicated"
-            operator: "Equal"
-            value: "experimental"
-            effect: "NoSchedule"
-    asserts:
-      - contains:
-          path: spec.template.spec.tolerations
-          content:
-            key: "dedicated"
-            operator: "Equal"
-            value: "experimental"
-            effect: "NoSchedule"
-
-  - it: "should add extra pod environment variables"
-    set:
-      controller:
-        env:
-          - name: EXTRA_ENV
-            value: extra_value
-    asserts:
-      - contains:
-          path: "spec.template.spec.containers[0].env"
-          content:
-            name: EXTRA_ENV
-            value: extra_value
-
-  - it: "should add extra pod labels"
-    set:
-      controller:
-        podLabels:
-          environment: production
-          team: infra
-    asserts:
-      - equal:
-          path: spec.template.metadata.labels.environment
-          value: production
-      - equal:
-          path: spec.template.metadata.labels.team
-          value: infra
-
-  - it: "should add extra pod annotations"
-    set:
-      controller:
-        podAnnotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "8443"
-    asserts:
-      - equal:
-          path: spec.template.metadata.annotations["prometheus.io/scrape"]
-          value: "true"
-      - equal:
-          path: spec.template.metadata.annotations["prometheus.io/port"]
-          value: "8443"
-
-  - it: "should set nodeSelector"
-    set:
-      controller:
-        nodeSelector:
-          kubernetes.io/os: linux
-          node-role: control-plane
-    asserts:
-      - equal:
-          path: spec.template.spec.nodeSelector["kubernetes.io/os"]
-          value: linux
-      - equal:
-          path: spec.template.spec.nodeSelector["node-role"]
-          value: control-plane
-
-  - it: "should not render nodeSelector when empty"
-    set:
-      controller:
-        nodeSelector: {}
-    asserts:
-      - notExists:
-          path: spec.template.spec.nodeSelector
-
-  - it: "should set affinity"
-    set:
-      controller:
-        affinity:
-          podAntiAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: runtime-enforcer
-                topologyKey: kubernetes.io/hostname
-    asserts:
-      - equal:
-          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey
-          value: kubernetes.io/hostname
-
-  - it: "should not render affinity when empty"
-    set:
-      controller:
-        affinity: {}
-    asserts:
-      - notExists:
-          path: spec.template.spec.affinity
+          content: "--wp-status-reconciler-agent-label-selector=app.kubernetes.io/compone\
+            nt=agent,app.kubernetes.io/instance=RELEASE-NAME,app.kubernetes.io/\
+            name=runtime-enforcer"

--- a/charts/runtime-enforcer/tests/deployment_test.yaml
+++ b/charts/runtime-enforcer/tests/deployment_test.yaml
@@ -4,9 +4,6 @@ templates:
 
 tests:
   - it: "should render component and default container"
-    set:
-      debugger:
-        enabled: true
     asserts:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/component"]

--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -46,8 +46,7 @@
                     "additionalProperties": true
                 },
                 "env": {
-                    "type": "array",
-                    "additionalProperties": true
+                    "type": "array"
                 },
                 "grpcExporterPort": {
                     "type": "string"
@@ -217,8 +216,7 @@
                     "additionalProperties": true
                 },
                 "env": {
-                    "type": "array",
-                    "additionalProperties": true
+                    "type": "array"
                 },
                 "image": {
                     "type": "object",
@@ -373,8 +371,7 @@
                     "type": "boolean"
                 },
                 "env": {
-                    "type": "array",
-                    "additionalProperties": true
+                    "type": "array"
                 },
                 "image": {
                     "type": "object",

--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -341,6 +341,10 @@
         "debugger": {
             "type": "object",
             "properties": {
+                "affinity": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "containerSecurityContext": {
                     "type": "object",
                     "properties": {
@@ -367,6 +371,10 @@
                 },
                 "enabled": {
                     "type": "boolean"
+                },
+                "env": {
+                    "type": "array",
+                    "additionalProperties": true
                 },
                 "image": {
                     "type": "object",
@@ -427,6 +435,9 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "tolerations": {
+                    "type": "array"
                 }
             },
             "additionalProperties": false

--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -56,6 +56,10 @@
                 },
                 "image": {
                     "type": "object",
+                    "required": [
+                        "repository",
+                        "tag"
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -220,6 +224,10 @@
                 },
                 "image": {
                     "type": "object",
+                    "required": [
+                        "repository",
+                        "tag"
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string"
@@ -375,6 +383,10 @@
                 },
                 "image": {
                     "type": "object",
+                    "required": [
+                        "repository",
+                        "tag"
+                    ],
                     "properties": {
                         "pullPolicy": {
                             "type": "string"

--- a/charts/runtime-enforcer/values.schema.json
+++ b/charts/runtime-enforcer/values.schema.json
@@ -406,6 +406,10 @@
                     "type": "object",
                     "additionalProperties": true
                 },
+                "podSecurityContext": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "resources": {
                     "type": "object",
                     "properties": {

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -166,6 +166,9 @@ debugger:
     requests:
       cpu: 500m
       memory: 256Mi
+  # The podSecurityContext used by debugger pods
+  # @schema additionalProperties:true
+  podSecurityContext: {}
   # debugger.podLabels -- Additional labels to add to the debugger pods.
   # @schema additionalProperties:true
   podLabels: {}

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -4,7 +4,6 @@ controller:
     - --leader-elect
     - --health-probe-bind-address=:8081
   # controller.env -- Additional environment variables
-  # @schema additionalProperties:true
   env: []
   # The containerSecurityContext used by runtime-enforcer controller
   # @schema additionalProperties:true
@@ -65,7 +64,6 @@ agent:
   args:
     - ""
   # agent.env -- Additional environment variables
-  # @schema additionalProperties:true
   env: []
   # The containerSecurityContext used by agent
   # @schema additionalProperties:true
@@ -144,7 +142,6 @@ imagePullSecrets: []
 
 debugger:
   # debugger.env -- Additional environment variables
-  # @schema additionalProperties:true
   env: []
   enabled: false
   interval: 30s

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -1,8 +1,8 @@
 controller:
   args:
-  - --metrics-bind-address=:8443
-  - --leader-elect
-  - --health-probe-bind-address=:8081
+    - --metrics-bind-address=:8443
+    - --leader-elect
+    - --health-probe-bind-address=:8081
   # controller.env -- Additional environment variables
   # @schema additionalProperties:true
   env: []
@@ -13,7 +13,7 @@ controller:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
   image:
     repository: ghcr.io/rancher-sandbox/runtime-enforcer/controller
     tag: v0.5.0
@@ -47,6 +47,7 @@ controller:
     # controller.serviceAccount.annotations -- Additional annotations to add to controller's service account.
     # @schema additionalProperties:true
     annotations: {}
+  # controller.tolerations -- Tolerations to apply on the controller pods
   tolerations: []
   # controller.podLabels -- Additional labels to add to the controller pods.
   # @schema additionalProperties:true
@@ -62,7 +63,7 @@ controller:
   affinity: {}
 agent:
   args:
-  - ""
+    - ""
   # agent.env -- Additional environment variables
   # @schema additionalProperties:true
   env: []
@@ -119,6 +120,7 @@ agent:
     # agent.serviceAccount.annotations -- Additional annotations to add to agent's service account.
     # @schema additionalProperties:true
     annotations: {}
+  # agent.tolerations -- Tolerations to apply on the agent pods
   tolerations: []
   # agent.podLabels -- Additional labels to add to the agent pods.
   # @schema additionalProperties:true
@@ -141,6 +143,9 @@ kubernetesClusterDomain: cluster.local
 imagePullSecrets: []
 
 debugger:
+  # debugger.env -- Additional environment variables
+  # @schema additionalProperties:true
+  env: []
   enabled: false
   interval: 30s
   # @schema additionalProperties:true
@@ -149,7 +154,7 @@ debugger:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
   image:
     repository: ghcr.io/rancher-sandbox/runtime-enforcer/debugger
     tag: v0.5.0
@@ -170,6 +175,11 @@ debugger:
   # debugger.nodeSelector -- Node selector for the debugger pods.
   # @schema additionalProperties:true
   nodeSelector: {}
+  # debugger.affinity -- Affinity rules for the debugger pods.
+  # @schema additionalProperties:true
+  affinity: {}
+  # debugger.tolerations -- Tolerations to apply on the debugger pods
+  tolerations: []
 
 # Learning mode configuration
 learning:

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -14,7 +14,11 @@ controller:
       drop:
         - ALL
   image:
+    # The image path used by controller
+    # @schema required
     repository: ghcr.io/rancher-sandbox/runtime-enforcer/controller
+    # The image tag used by controller
+    # @schema required
     tag: v0.5.0
     pullPolicy: IfNotPresent
   logLevel: info # @schema enum: [debug, info, warn, error]
@@ -86,7 +90,11 @@ agent:
       drop:
         - ALL
   image:
+    # The image path used by agent
+    # @schema required
     repository: ghcr.io/rancher-sandbox/runtime-enforcer/agent
+    # The image tag used by agent
+    # @schema required
     tag: v0.5.0
     pullPolicy: IfNotPresent
   grpcExporterPort: "50051"
@@ -153,7 +161,11 @@ debugger:
       drop:
         - ALL
   image:
+    # The image path used by debugger
+    # @schema required
     repository: ghcr.io/rancher-sandbox/runtime-enforcer/debugger
+    # The image tag used by debugger
+    # @schema required
     tag: v0.5.0
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

This PR refactors the current helm unit-tests to ensure common configurations can be applied to all runtime enforcement pods correctly:
   - image path/tag
   - imagePullPolicy
   - tolerations
   - env var
   - extra labels
   - extra annotations
   - nodeSelector
   - affinity

In addition, these issues are fixed along the way:

1. Implement envvars, toleration, affinity and imagePullSecrets support for debugger.
2. Add missing labels to controller/agent pods

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

It's easier to review commit by commit. 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
