### PR TITLE
docs: remove pharase minikube is not supported

### DIFF
--- a/docs/setup-development-env.md
+++ b/docs/setup-development-env.md
@@ -11,7 +11,7 @@ Runtime enforcer supports Tilt to run development environment in your local.
 
 ## Pre-requisite
 
-- On a supported Linux host to run a local kubernetes cluster, install a one node kubernetes cluster.  Minikube is not supported.
+- On a supported Linux host to run a local kubernetes cluster, install a one node kubernetes cluster.
 - Setup golang development environments.
 
 ## Steps


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Given that we've been using minikube in many occasions, let's remove the phrase saying minikube is not supported in developer docs. 

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
