### PR TITLE
chore: restore envtest version to the one derived by controller-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ HELM_VALUES_SCHEMA_JSON ?= $(LOCALBIN)/helm-values-schema-json
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
-ENVTEST_VERSION ?= release-0.23
+ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.63.4


### PR DESCRIPTION
Restoring the `envtest` version to the one specified by `controller-runtime` now that the last matching version was published.
