### PR TITLE
fix: pin ubuntu version to 24.04

### DIFF
--- a/docs/troubleshooting.adoc
+++ b/docs/troubleshooting.adoc
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         stdin: true
         tty: true
 ----

--- a/docs/yaml/ubuntu-deployment.yaml
+++ b/docs/yaml/ubuntu-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         # We create a while loop to continually run sleep and ls.
         # This way we can detect two groups of processes in our test:
         # - process snapshot (bash)

--- a/test/e2e/policy_per_container_test.go
+++ b/test/e2e/policy_per_container_test.go
@@ -75,14 +75,14 @@ func getPolicyPerContainerTest() types.Feature {
 						InitContainers: []corev1.Container{
 							{
 								Name:    "init-container",
-								Image:   "ubuntu",
+								Image:   "ubuntu:24.04",
 								Command: []string{"echo", "init completed"},
 							},
 						},
 						Containers: []corev1.Container{
 							{
 								Name:    "main-container",
-								Image:   "ubuntu",
+								Image:   "ubuntu:24.04",
 								Command: []string{"sleep", "3600"},
 							},
 						},
@@ -137,14 +137,14 @@ func getPolicyPerContainerTest() types.Feature {
 						InitContainers: []corev1.Container{
 							{
 								Name:    "init-container",
-								Image:   "ubuntu",
+								Image:   "ubuntu:24.04",
 								Command: []string{"date"},
 							},
 						},
 						Containers: []corev1.Container{
 							{
 								Name:    "main-container",
-								Image:   "ubuntu",
+								Image:   "ubuntu:24.04",
 								Command: []string{"sleep", "3600"},
 							},
 						},

--- a/test/e2e/policy_update_test.go
+++ b/test/e2e/policy_update_test.go
@@ -69,12 +69,12 @@ func getPolicyUpdateTest() types.Feature {
 					Containers: []corev1.Container{
 						{
 							Name:    mainContainer,
-							Image:   "ubuntu",
+							Image:   "ubuntu:24.04",
 							Command: []string{"sleep", "3600"},
 						},
 						{
 							Name:    sidecarContainer,
-							Image:   "ubuntu",
+							Image:   "ubuntu:24.04",
 							Command: []string{"sleep", "3600"},
 						},
 					},

--- a/test/e2e/testdata/ubuntu-cronjob.yaml
+++ b/test/e2e/testdata/ubuntu-cronjob.yaml
@@ -12,6 +12,6 @@ spec:
           terminationGracePeriodSeconds: 1
           containers:
           - name: ubuntu
-            image: ubuntu
+            image: ubuntu:24.04
             command: ["bash", "-c", "sleep 5; ls"]
           restartPolicy: Never

--- a/test/e2e/testdata/ubuntu-daemonset.yaml
+++ b/test/e2e/testdata/ubuntu-daemonset.yaml
@@ -19,5 +19,5 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         command: ["bash", "-c", "while true; do sleep 5; ls; done"]

--- a/test/e2e/testdata/ubuntu-deployment.yaml
+++ b/test/e2e/testdata/ubuntu-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         # We create a while loop to continually run sleep and ls.
         # This way we can detect two groups of processes in our test:
         # - process snapshot (bash)

--- a/test/e2e/testdata/ubuntu-job.yaml
+++ b/test/e2e/testdata/ubuntu-job.yaml
@@ -9,6 +9,6 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         command: ["bash", "-c", "while true; do sleep 5; ls; done"]
       restartPolicy: OnFailure

--- a/test/e2e/testdata/ubuntu-replicaset.yaml
+++ b/test/e2e/testdata/ubuntu-replicaset.yaml
@@ -20,5 +20,5 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         command: ["bash", "-c", "while true; do sleep 5; ls; done"]

--- a/test/e2e/testdata/ubuntu-statefulset.yaml
+++ b/test/e2e/testdata/ubuntu-statefulset.yaml
@@ -20,5 +20,5 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: ubuntu
-        image: ubuntu
+        image: ubuntu:24.04
         command: ["bash", "-c", "while true; do sleep 5; ls; done"]


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Pin the ubuntu version to 24.04

This is because ubuntu 26.04 switched to the rust-version of coreutils and so the binary paths are changed:
* /bin/true => /bin/gnutrue
* /usr/bin/echo => /usr/lib/cargo/bin/coreutils/echo
* /usr/bin/ls => /usr/lib/cargo/bin/coreutils/ls
* /usr/bin/sleep => /usr/lib/cargo/bin/coreutils/sleep
* /usr/bin/cat => /usr/lib/cargo/bin/coreutils/cat

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
