### PR TITLE
fix: add -r flag to jq in SBOM digest extraction

### DIFF
--- a/.github/actions/attestation/action.yaml
+++ b/.github/actions/attestation/action.yaml
@@ -100,7 +100,7 @@ runs:
         run: |
           set -e
           DIGEST=$(${CRANE_PATH}/crane manifest ghcr.io/${INPUTS_REPO}/${INPUTS_IMAGE}@${ATTESTATION_MANIFEST_DIGEST} |  \
-            jq '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
+            jq -r '.layers | map(select(.annotations["in-toto.io/predicate-type"] == "https://spdx.dev/Document")) | map(.digest) | join(" ")')
           echo "SBOM_DIGEST=${DIGEST}" >> "$GITHUB_OUTPUT"
         env:
           CRANE_PATH: ${{ steps.install-crane.outputs.CRANE_PATH }}


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Without -r, jq emits a JSON-encoded string with literal quotes around the digest, which get propagated through `$GITHUB_OUTPUT` into the downstream `crane blob` call. This PR fixes it.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
