### PR TITLE
fix(ci): install linters before running pre-commit run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,18 @@ jobs:
             llvm \
             libbpf-dev
           pip install pre-commit
+      - name: Cache precommit linters
+        id: cache-precommit-linters
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pre-commit/
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Generate eBPF code
         run: make generate-ebpf
+      - name: Install linters
+        run: |
+          pre-commit install --install-hooks
       - name: Run linters
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Currently pre-commit run would fail due to some linter binaries are still locked or not executable.

This is an attempt to install linters separately, so it gives the installation flow a little extra time to settle.

So far it succeeded in my fork 4 times without errors. I propose that we merge this and keep monitoring. 

Also added back precommit cache.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
