### PR TITLE
chore: do not publish helm chart as the latest release

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -1,2 +1,3 @@
 release-name-template: "{{.Name}}-chart-{{.Version}}"
 skip-existing: true
+make-release-latest: false


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Do not publish helm chart as the latest release as this would prevent kubectl plugin download.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
