### PR TITLE
feat(helm): make imagePullSecrets more user friendly

### DIFF
--- a/charts/runtime-enforcer/templates/_helpers.tpl
+++ b/charts/runtime-enforcer/templates/_helpers.tpl
@@ -100,3 +100,18 @@ Usage:
 {{- define "runtime-enforcer.agent.labelSelectorString" -}}
 {{- include "runtime-enforcer.labelSelectorToString" (include "runtime-enforcer.agent.labelSelector" .) -}}
 {{- end -}}
+
+{{/*
+Print the image pull secrets in the expected format (an array of objects with one possible field, "name").
+*/}}
+{{- define "imagePullSecrets" }}
+    {{- $imagePullSecrets := list }}
+    {{- range . }}
+        {{- if kindIs "string" . }}
+            {{- $imagePullSecrets = append $imagePullSecrets (dict "name" .) }}
+        {{- else }}
+            {{- $imagePullSecrets = append $imagePullSecrets . }}
+        {{- end }}
+    {{- end }}
+    {{- toYaml $imagePullSecrets }}
+{{- end }}

--- a/charts/runtime-enforcer/templates/agent/daemonset.yaml
+++ b/charts/runtime-enforcer/templates/agent/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - args:

--- a/charts/runtime-enforcer/templates/controller/deployment.yaml
+++ b/charts/runtime-enforcer/templates/controller/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - args: 

--- a/charts/runtime-enforcer/templates/debugger/deployment.yaml
+++ b/charts/runtime-enforcer/templates/debugger/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext: {{- toYaml .Values.debugger.podSecurityContext | nindent 8 }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - name: debugger

--- a/charts/runtime-enforcer/templates/otel-collector/deployment.yaml
+++ b/charts/runtime-enforcer/templates/otel-collector/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-      {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- include "imagePullSecrets" .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - name: otel-collector

--- a/charts/runtime-enforcer/values.yaml
+++ b/charts/runtime-enforcer/values.yaml
@@ -144,8 +144,9 @@ agent:
   nriFailopen: false
 kubernetesClusterDomain: cluster.local
 
-## Optional array of imagePullSecrets containing private registry credentials
-## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# Optional array of imagePullSecrets containing private registry credentials
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# Each entry can be a plain secret name (string) or a {name: ...} object.
 imagePullSecrets: []
 
 debugger:


### PR DESCRIPTION
Allow both simple strings and `{name:}` as input of `imagePullSecrets`.

This takes inspiration from Kubewarden admission controller.
