### PR TITLE
refactor: rename policy labels

### DIFF
--- a/api/v1alpha1/keys.go
+++ b/api/v1alpha1/keys.go
@@ -1,0 +1,15 @@
+package v1alpha1
+
+const (
+	// ProposalPromoteLabelKey is set on a WorkloadPolicyProposal when it is promoted to a WorkloadPolicy.
+	ProposalPromoteLabelKey = "security.rancher.io/promote"
+
+	// PolicyPromotedFromLabelKey is set on a WorkloadPolicy when it is created by
+	// promoting a WorkloadPolicyProposal.
+	// The learning controller uses it to avoid recreating proposals for
+	// workloads that are already protected by an existing policy.
+	PolicyPromotedFromLabelKey = "security.rancher.io/promoted-from"
+
+	// PolicyLabelKey is set on a Workload to identify to bind it to a specific policy.
+	PolicyLabelKey = "security.rancher.io/policy"
+)

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -219,7 +219,8 @@ func (wp *WorkloadPolicy) SetPromotedLabel(proposalName string) error {
 		return errors.New("WorkloadPolicy is nil")
 	}
 
-	// k8s labels must have 63 chars or less.
+	// Valid k8s label value must be 63 characters or less.
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 	// We catch here the error instead of letting the API server handle it.
 	const maxLabelValueLength = 63
 	if len(proposalName) > maxLabelValueLength {

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
@@ -13,12 +15,6 @@ const (
 )
 
 const (
-	// PromotedFromLabelKey is set on a WorkloadPolicy when it is created by
-	// promoting a WorkloadPolicyProposal.
-	// The learning controller uses it to avoid recreating proposals for
-	// workloads that are already protected by an existing policy.
-	PromotedFromLabelKey = "workloadpolicy.security.rancher.io/promoted-from"
-
 	// MaxNodesWithIssues is the maximum number of nodes with issues to report.
 	// we don't want to overwhelm the user with too much information.
 	MaxNodesWithIssues = 20
@@ -216,6 +212,33 @@ func (wp *WorkloadPolicy) NamespacedName() string {
 		return ""
 	}
 	return wp.Namespace + "/" + wp.Name
+}
+
+func (wp *WorkloadPolicy) SetPromotedLabel(proposalName string) error {
+	if wp == nil {
+		return errors.New("WorkloadPolicy is nil")
+	}
+
+	// k8s labels must have 63 chars or less.
+	// We catch here the error instead of letting the API server handle it.
+	const maxLabelValueLength = 63
+	if len(proposalName) > maxLabelValueLength {
+		return fmt.Errorf("proposalName %q is too long", proposalName)
+	}
+
+	if wp.Labels == nil {
+		wp.SetLabels(map[string]string{})
+	}
+
+	wp.Labels[PolicyPromotedFromLabelKey] = proposalName
+	return nil
+}
+
+func (wp *WorkloadPolicy) HasPromotedLabel(proposalName string) bool {
+	if wp == nil {
+		return false
+	}
+	return wp.Labels[PolicyPromotedFromLabelKey] == proposalName
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -11,8 +11,6 @@ const (
 	// PolicyProposalMaxExecutables defines the maximum number of executables that we can learn.
 	// This is a arbitrary number right now and can be fine-tuned or made configurable in the future.
 	PolicyProposalMaxExecutables = 100
-	ApprovalLabelKey             = "security.rancher.io/policy-ready"
-	PolicyLabelKey               = "security.rancher.io/policy"
 )
 
 // WorkloadPolicyProposalSpec defines the desired state of WorkloadPolicyProposal.
@@ -67,6 +65,23 @@ func (p *WorkloadPolicyProposal) NamespacedName() string {
 		return ""
 	}
 	return p.Namespace + "/" + p.Name
+}
+
+func (p *WorkloadPolicyProposal) SetPromotionLabel() {
+	if p == nil {
+		return
+	}
+	if p.Labels == nil {
+		p.SetLabels(map[string]string{})
+	}
+	p.Labels[ProposalPromoteLabelKey] = "true"
+}
+
+func (p *WorkloadPolicyProposal) HasPromotionLabel() bool {
+	if p == nil {
+		return false
+	}
+	return p.Labels[ProposalPromoteLabelKey] == "true"
 }
 
 func (p *WorkloadPolicyProposal) IsFull() bool {

--- a/internal/controller/workloadpolicyproposal_controller.go
+++ b/internal/controller/workloadpolicyproposal_controller.go
@@ -63,7 +63,7 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
-	if proposal.GetLabels()[securityv1alpha1.ApprovalLabelKey] != "true" {
+	if !proposal.HasPromotionLabel() {
 		return ctrl.Result{}, nil
 	}
 
@@ -71,11 +71,11 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      proposal.Name,
 			Namespace: proposal.Namespace,
-			Labels: map[string]string{
-				securityv1alpha1.PromotedFromLabelKey: proposal.Name,
-			},
 		},
 		Spec: proposal.Spec.IntoWorkloadPolicySpec(),
+	}
+	if err = policy.SetPromotedLabel(proposal.Name); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set promoted label: %w", err)
 	}
 
 	if err = r.Create(ctx, &policy); err != nil {

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -282,8 +282,7 @@ func (r *LearningReconciler) reconcile(
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {
 		// We don't learn any new process if the policy proposal was promoted
 		// to an actual policy
-		labels := policyProposal.GetLabels()
-		if labels[securityv1alpha1.ApprovalLabelKey] == "true" {
+		if policyProposal.HasPromotionLabel() {
 			return nil
 		}
 

--- a/internal/eventhandler/learning_controller_test.go
+++ b/internal/eventhandler/learning_controller_test.go
@@ -332,10 +332,7 @@ var _ = Describe("Learning", func() {
 			testProposal := proposal.DeepCopy()
 			testProposal.Namespace = testNamespace
 			testProposal.Name = testProposalName
-			labels := map[string]string{}
-			labels[securityv1alpha1.ApprovalLabelKey] = "true"
-			testProposal.SetLabels(labels)
-
+			testProposal.SetPromotionLabel()
 			Expect(k8sClient.Create(ctx, testProposal)).To(Succeed())
 
 			for _, learningEvent := range processEvents {
@@ -388,14 +385,12 @@ var _ = Describe("Learning", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testProposalName,
 					Namespace: testNamespace,
-					Labels: map[string]string{
-						securityv1alpha1.PromotedFromLabelKey: testProposalName,
-					},
 				},
 				Spec: securityv1alpha1.WorkloadPolicySpec{
 					Mode: "monitor",
 				},
 			}
+			Expect(workloadPolicy.SetPromotedLabel(testProposalName)).To(Succeed())
 			Expect(k8sClient.Create(ctx, workloadPolicy)).To(Succeed())
 
 			for _, learningEvent := range processEvents {

--- a/internal/eventhandler/proposalutils/proposalutils.go
+++ b/internal/eventhandler/proposalutils/proposalutils.go
@@ -64,7 +64,7 @@ func HasProposalBeenPromoted(
 		&workloadPolicies,
 		client.InNamespace(namespace),
 		client.MatchingLabels{
-			securityv1alpha1.PromotedFromLabelKey: proposalName,
+			securityv1alpha1.PolicyPromotedFromLabelKey: proposalName,
 		},
 	); err != nil {
 		return false, err

--- a/internal/eventhandler/proposalutils/proposalutils_test.go
+++ b/internal/eventhandler/proposalutils/proposalutils_test.go
@@ -99,7 +99,7 @@ func TestHasProposalBeenPromoted(t *testing.T) {
 					Namespace: defaultNamespace,
 					Name:      proposalName,
 					Labels: map[string]string{
-						securityv1alpha1.PromotedFromLabelKey: proposalName,
+						securityv1alpha1.PolicyPromotedFromLabelKey: proposalName,
 					},
 				},
 			},

--- a/internal/kubectlplugin/proposal_promote.go
+++ b/internal/kubectlplugin/proposal_promote.go
@@ -91,12 +91,7 @@ func runProposalPromote(
 		)
 	}
 
-	labels := proposal.GetLabels()
-	if labels == nil {
-		labels = map[string]string{}
-	}
-
-	if labels[apiv1alpha1.ApprovalLabelKey] == "true" {
+	if proposal.HasPromotionLabel() {
 		fmt.Fprintf(
 			out,
 			"WorkloadPolicyProposal %q in namespace %q is already promoted to WorkloadPolicy.\n",
@@ -111,8 +106,7 @@ func runProposalPromote(
 		updateOptions.DryRun = []string{metav1.DryRunAll}
 	}
 
-	labels[apiv1alpha1.ApprovalLabelKey] = "true"
-	proposal.SetLabels(labels)
+	proposal.SetPromotionLabel()
 
 	if _, err = client.WorkloadPolicyProposals(opts.Namespace).
 		Update(ctx, proposal, updateOptions); err != nil {

--- a/internal/kubectlplugin/proposal_promote_test.go
+++ b/internal/kubectlplugin/proposal_promote_test.go
@@ -75,7 +75,7 @@ func TestRunProposalPromote(t *testing.T) {
 					Name:      name,
 					Namespace: ns,
 					Labels: map[string]string{
-						securityv1alpha1.ApprovalLabelKey: "true",
+						securityv1alpha1.ProposalPromoteLabelKey: "true",
 					},
 				},
 			},
@@ -112,9 +112,7 @@ func TestRunProposalPromote(t *testing.T) {
 
 			// The fake client ignores DryRun and still mutates the object, so we
 			// still assert the updated label even in dry-run mode.
-			labels := wpProposal.GetLabels()
-			require.NotNil(t, labels)
-			require.Equal(t, "true", labels[securityv1alpha1.ApprovalLabelKey])
+			require.True(t, wpProposal.HasPromotionLabel())
 			require.Contains(t, out.String(), tt.expectOutput)
 		})
 	}

--- a/test/e2e/promotion_test.go
+++ b/test/e2e/promotion_test.go
@@ -97,16 +97,9 @@ func getPromotionTest() types.Feature {
 				r := getClient(ctx)
 				proposal := ctx.Value(key("proposal")).(*v1alpha1.WorkloadPolicyProposal)
 
-				t.Log("applying the label to the policy proposal: ", proposal.Name, v1alpha1.ApprovalLabelKey)
+				t.Log("promote the policy proposal: ", proposal.Name)
 
-				labels := proposal.GetLabels()
-				if labels == nil {
-					labels = map[string]string{}
-				}
-
-				labels[v1alpha1.ApprovalLabelKey] = "true"
-
-				proposal.SetLabels(labels)
+				proposal.SetPromotionLabel()
 				err := r.Update(ctx, proposal)
 				require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Following what we did in the network enforcer (https://github.com/rancher-sandbox/network-enforcer/pull/61) I'm renaming the labels also in the runtime enforcer.
* `"workloadpolicy.security.rancher.io/promoted-from"` -> `"security.rancher.io/promoted-from"`
* `"security.rancher.io/policy-ready"` -> `"security.rancher.io/promote"`

**Which issue(s) this PR fixes**


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
