### PR TITLE
refactor: use `t.Output()` method in test logger

### DIFF
--- a/internal/resolver/mock_resolver.go
+++ b/internal/resolver/mock_resolver.go
@@ -1,10 +1,10 @@
 package resolver
 
 import (
-	"log/slog"
 	"testing"
 
 	"github.com/rancher-sandbox/runtime-enforcer/internal/bpf"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"github.com/stretchr/testify/require"
 )
@@ -25,20 +25,10 @@ func mockCgroupToPolicyMapUpdateFunc(_ PolicyID, _ []CgroupID, _ bpf.CgroupPolic
 	return nil
 }
 
-type testWriter struct {
-	t testing.TB
-}
-
-func (w testWriter) Write(p []byte) (int, error) {
-	w.t.Helper()
-	w.t.Log(string(p))
-	return len(p), nil
-}
-
 func NewTestResolver(t testing.TB) *Resolver {
 	t.Helper()
 	r, err := NewResolver(
-		slog.New(slog.NewJSONHandler(testWriter{t}, nil)),
+		testutil.NewTestLogger(t),
 		mockCgTrackerUpdateFunc,
 		mockCgroupToPolicyMapUpdateFunc,
 		mockPolicyUpdateBinariesFunc,

--- a/internal/testutil/logger.go
+++ b/internal/testutil/logger.go
@@ -5,18 +5,9 @@ import (
 	"testing"
 )
 
-type testLogWriter struct {
-	t *testing.T
-}
-
-func (w *testLogWriter) Write(p []byte) (int, error) {
-	w.t.Logf("%s", string(p))
-	return len(p), nil
-}
-
 // NewTestLogger returns an [slog.Logger] that writes to t.Logf.
-func NewTestLogger(t *testing.T) *slog.Logger {
-	return slog.New(slog.NewJSONHandler(&testLogWriter{t: t}, &slog.HandlerOptions{
+func NewTestLogger(t testing.TB) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(t.Output(), &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})).With("component", t.Name())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces `t.Output()` method in test logger

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
