### PR TITLE
refactor: rework WP status management [5/n]

### DIFF
--- a/api/v1alpha1/policy_node_status.go
+++ b/api/v1alpha1/policy_node_status.go
@@ -86,7 +86,7 @@ func (s *WorkloadPolicyStatus) resetPolicyNodeStatus(totalNodes int) {
 	s.TransitioningNodes = 0
 }
 
-func (s *WorkloadPolicyStatus) ProcessPolicyNodeStatus(nodes []PolicyNodeStatus) error {
+func (s *WorkloadPolicyStatus) processPolicyNodeStatus(nodes []PolicyNodeStatus) error {
 	s.resetPolicyNodeStatus(len(nodes))
 
 	for _, status := range nodes {

--- a/api/v1alpha1/policy_node_status_test.go
+++ b/api/v1alpha1/policy_node_status_test.go
@@ -108,7 +108,7 @@ func TestProcessPolicyNodeStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			wpStatus := WorkloadPolicyStatus{}
-			wpStatus.ProcessPolicyNodeStatus(tt.nodes)
+			wpStatus.processPolicyNodeStatus(tt.nodes)
 			require.Equal(t, tt.expected, wpStatus)
 		})
 	}

--- a/api/v1alpha1/violation_record.go
+++ b/api/v1alpha1/violation_record.go
@@ -83,9 +83,9 @@ func (wp *WorkloadPolicy) clearAllowedViolations() {
 	})
 }
 
-// MergeScrapedViolations dedupes scraped violations against the existing list, allocate ids for
+// mergeScrapedViolations dedupes scraped violations against the existing list, allocate ids for
 // new records and refresh the timestamp/node on matched records.
-func (s *WorkloadPolicyStatus) MergeScrapedViolations(scraped []ViolationRecord) {
+func (s *WorkloadPolicyStatus) mergeScrapedViolations(scraped []ViolationRecord) {
 	indexByKey := make(map[violationRecordKey]int, len(s.Violations))
 	for i, r := range s.Violations {
 		indexByKey[r.key()] = i

--- a/api/v1alpha1/violation_record.go
+++ b/api/v1alpha1/violation_record.go
@@ -94,7 +94,12 @@ func (s *WorkloadPolicyStatus) MergeScrapedViolations(scraped []ViolationRecord)
 	for _, v := range scraped {
 		key := v.key()
 		if idx, ok := indexByKey[key]; ok {
-			s.Violations[idx].Timestamp = v.Timestamp
+			// We need to overwrite the timestamp only if it is newer.
+			// if in a same batch we have multiple occurrences of the violation
+			// we just need to store the one with the highest timestamp.
+			if v.Timestamp.Time.After(s.Violations[idx].Timestamp.Time) {
+				s.Violations[idx].Timestamp = v.Timestamp
+			}
 		} else {
 			v.ID = s.ViolationCount
 			s.Violations = append(s.Violations, v)

--- a/api/v1alpha1/violation_record.go
+++ b/api/v1alpha1/violation_record.go
@@ -76,7 +76,7 @@ func (r ViolationRecord) key() violationRecordKey {
 	}
 }
 
-func (wp *WorkloadPolicy) ClearAllowed() {
+func (wp *WorkloadPolicy) clearAllowedViolations() {
 	wp.Status.Violations = slices.DeleteFunc(wp.Status.Violations, func(v ViolationRecord) bool {
 		rules := wp.Spec.RulesByContainer[v.ContainerName]
 		return rules != nil && slices.Contains(rules.Executables.Allowed, v.ExecutablePath)

--- a/api/v1alpha1/violation_record.go
+++ b/api/v1alpha1/violation_record.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const MaxViolationRecords = 100
+const maxViolationRecords = 100
 
 // ViolationRecord holds the details of a single policy violation.
 type ViolationRecord struct {
@@ -112,8 +112,8 @@ func (s *WorkloadPolicyStatus) MergeScrapedViolations(scraped []ViolationRecord)
 		return b.Timestamp.Time.Compare(a.Timestamp.Time)
 	})
 
-	if len(s.Violations) > MaxViolationRecords {
-		s.Violations = s.Violations[:MaxViolationRecords]
+	if len(s.Violations) > maxViolationRecords {
+		s.Violations = s.Violations[:maxViolationRecords]
 	}
 }
 
@@ -185,8 +185,8 @@ func (wp *WorkloadPolicy) AcknowledgeViolationsFromAnnotations(now metav1.Time) 
 		return b.AcknowledgedAt.Time.Compare(a.AcknowledgedAt.Time)
 	})
 
-	if len(wp.Status.AcknowledgedViolations) > MaxViolationRecords {
-		wp.Status.AcknowledgedViolations = wp.Status.AcknowledgedViolations[:MaxViolationRecords]
+	if len(wp.Status.AcknowledgedViolations) > maxViolationRecords {
+		wp.Status.AcknowledgedViolations = wp.Status.AcknowledgedViolations[:maxViolationRecords]
 	}
 	return ackToReturn
 }

--- a/api/v1alpha1/violation_record.go
+++ b/api/v1alpha1/violation_record.go
@@ -117,7 +117,7 @@ func (s *WorkloadPolicyStatus) mergeScrapedViolations(scraped []ViolationRecord)
 	}
 }
 
-func (wp *WorkloadPolicy) AcknowledgeViolationsFromAnnotations(now metav1.Time) []AcknowledgedViolationRecord {
+func (wp *WorkloadPolicy) acknowledgeViolationsFromAnnotations(now metav1.Time) []AcknowledgedViolationRecord {
 	annotations := wp.GetAnnotations()
 	// No annotations -> no violations to acknowledge
 	if len(annotations) == 0 {

--- a/api/v1alpha1/violation_record_test.go
+++ b/api/v1alpha1/violation_record_test.go
@@ -388,7 +388,7 @@ func TestAcknowledgeViolationsFromAnnotations(t *testing.T) {
 				},
 			}
 
-			returned := wp.AcknowledgeViolationsFromAnnotations(now)
+			returned := wp.acknowledgeViolationsFromAnnotations(now)
 
 			require.Equal(t, tt.wantAnnotations, wp.GetAnnotations())
 			require.ElementsMatch(t, tt.wantViolations, wp.Status.Violations)

--- a/api/v1alpha1/violation_record_test.go
+++ b/api/v1alpha1/violation_record_test.go
@@ -20,6 +20,11 @@ func (r ViolationRecord) withPodName(name string) ViolationRecord {
 	return r
 }
 
+func (r ViolationRecord) withNodeName(name string) ViolationRecord {
+	r.NodeName = name
+	return r
+}
+
 func (r ViolationRecord) withContainerName(name string) ViolationRecord {
 	r.ContainerName = name
 	return r

--- a/api/v1alpha1/violation_record_test.go
+++ b/api/v1alpha1/violation_record_test.go
@@ -251,7 +251,7 @@ func TestClearAllowedViolations(t *testing.T) {
 				Spec:   WorkloadPolicySpec{RulesByContainer: tt.rules},
 				Status: WorkloadPolicyStatus{Violations: tt.violations},
 			}
-			wp.ClearAllowed()
+			wp.clearAllowedViolations()
 			require.Equal(t, tt.expected, wp.Status.Violations)
 		})
 	}

--- a/api/v1alpha1/violation_record_test.go
+++ b/api/v1alpha1/violation_record_test.go
@@ -186,7 +186,7 @@ func TestMergeScrapedViolations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.initialStatus.MergeScrapedViolations(tt.scraped)
+			tt.initialStatus.mergeScrapedViolations(tt.scraped)
 			require.Equal(t, tt.expectedStatus, tt.initialStatus)
 		})
 	}

--- a/api/v1alpha1/violation_record_test.go
+++ b/api/v1alpha1/violation_record_test.go
@@ -155,7 +155,7 @@ func TestMergeScrapedViolations(t *testing.T) {
 					withTimestamp(baseTS.Add(time.Duration(101) * time.Minute)),
 			},
 			initialStatus: func() WorkloadPolicyStatus {
-				r := make([]ViolationRecord, MaxViolationRecords)
+				r := make([]ViolationRecord, maxViolationRecords)
 				for i := range r {
 					r[i] = baseViolation.withExecutable(fmt.Sprintf("/%d", i+1)).
 						withID(int64(i)).
@@ -167,7 +167,7 @@ func TestMergeScrapedViolations(t *testing.T) {
 				}
 			}(),
 			expectedStatus: func() WorkloadPolicyStatus {
-				r := make([]ViolationRecord, MaxViolationRecords+1)
+				r := make([]ViolationRecord, maxViolationRecords+1)
 				for i := range r {
 					r[i] = baseViolation.withExecutable(fmt.Sprintf("/%d", i+1)).
 						withID(int64(i)).
@@ -177,7 +177,7 @@ func TestMergeScrapedViolations(t *testing.T) {
 					return b.Timestamp.Time.Compare(a.Timestamp.Time)
 				})
 				return WorkloadPolicyStatus{
-					Violations:     r[:MaxViolationRecords],
+					Violations:     r[:maxViolationRecords],
 					ViolationCount: 101,
 				}
 			}(),
@@ -354,7 +354,7 @@ func TestAcknowledgeViolationsFromAnnotations(t *testing.T) {
 			violations: []ViolationRecord{newViolation(101)},
 			// This policy already has an acknowledged violation, that should remain untouched
 			acknowledged: func() []AcknowledgedViolationRecord {
-				r := make([]AcknowledgedViolationRecord, MaxViolationRecords)
+				r := make([]AcknowledgedViolationRecord, maxViolationRecords)
 				for i := range r {
 					r[i] = newAck(int64(i), "acknowledged", now)
 				}
@@ -363,15 +363,15 @@ func TestAcknowledgeViolationsFromAnnotations(t *testing.T) {
 			wantAnnotations: map[string]string{},
 			wantViolations:  []ViolationRecord{},
 			wantAcknowledged: func() []AcknowledgedViolationRecord {
-				r := make([]AcknowledgedViolationRecord, MaxViolationRecords+1)
+				r := make([]AcknowledgedViolationRecord, maxViolationRecords+1)
 				for i := range r {
 					r[i] = newAck(int64(i), "acknowledged", now)
 				}
-				r[MaxViolationRecords] = newAck(101, "acknowledged", now)
+				r[maxViolationRecords] = newAck(101, "acknowledged", now)
 				slices.SortFunc(r, func(a, b AcknowledgedViolationRecord) int {
 					return b.AcknowledgedAt.Time.Compare(a.AcknowledgedAt.Time)
 				})
-				return r[:MaxViolationRecords]
+				return r[:maxViolationRecords]
 			}(),
 			wantReturned: []AcknowledgedViolationRecord{
 				newAck(101, "acknowledged", now),

--- a/api/v1alpha1/workloadpolicy_test.go
+++ b/api/v1alpha1/workloadpolicy_test.go
@@ -1,15 +1,16 @@
-package v1alpha1_test
+package v1alpha1
 
 import (
 	"testing"
+	"time"
 
-	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestWorkloadPolicyNamespacedName(t *testing.T) {
-	wp := &v1alpha1.WorkloadPolicy{
+	wp := &WorkloadPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
 			Name:      "test-name",
@@ -17,4 +18,170 @@ func TestWorkloadPolicyNamespacedName(t *testing.T) {
 	}
 	expected := "test-namespace/test-name"
 	require.Equal(t, expected, wp.NamespacedName())
+}
+
+func TestRecomputeStatus(t *testing.T) {
+	// This test should simulate a real flow
+	const (
+		forgottenBinary = "/usr/bin/cat"
+		containerName   = "example"
+		workloadName    = "example-workload"
+		workloadKind    = "Deployment"
+		podA            = "pod-a"
+		nodeA           = "node-a"
+		podB            = "pod-b"
+		nodeB           = "node-b"
+	)
+	baseViolation := ViolationRecord{
+		ContainerName:  containerName,
+		ExecutablePath: forgottenBinary,
+		Action:         policymode.ProtectString,
+		WorkloadName:   workloadName,
+		WorkloadKind:   workloadKind,
+	}
+	podAViolation := baseViolation.withPodName(podA).withNodeName(nodeA)
+	podBViolation := baseViolation.withPodName(podB).withNodeName(nodeB)
+	baseTS := time.Date(2026, 3, 1, 9, 0, 0, 0, time.UTC)
+	ts := func(sec int) time.Time {
+		return baseTS.Add(time.Duration(sec) * time.Second)
+	}
+
+	policy := &WorkloadPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation:  7,
+			Annotations: map[string]string{},
+		},
+		Spec: WorkloadPolicySpec{
+			RulesByContainer: map[string]*WorkloadPolicyRules{
+				containerName: {Executables: WorkloadPolicyExecutables{Allowed: []string{
+					"/usr/bin/sh",
+					"/usr/bin/ls",
+				}}},
+			},
+		},
+		Status: WorkloadPolicyStatus{
+			ViolationCount:       0,
+			ActiveViolationCount: 0,
+		},
+	}
+
+	///////////////////////////
+	// the user forgot a binary "/usr/bin/cat"
+	///////////////////////////
+
+	// If the application is a deployment we expect multiple violations from different nodes
+	violations := []ViolationRecord{
+		// The agent should send newest records first
+		podAViolation.withTimestamp(ts(1)),
+		podAViolation.withTimestamp(ts(2)),
+		podBViolation.withTimestamp(ts(3)),
+		podAViolation.withTimestamp(ts(4)),
+	}
+
+	policy.RecomputeStatus(nil, violations, ts(5))
+	expectedPolicyStatus := WorkloadPolicyStatus{
+		ViolationCount:       4,
+		ActiveViolationCount: 2,
+		Violations: []ViolationRecord{
+			podAViolation.withID(0).withTimestamp(ts(4)),
+			// This has ID 2 because we first face 2 violation for pod-a
+			podBViolation.withID(2).withTimestamp(ts(3)),
+		},
+		ObservedGeneration: 7,
+		Phase:              Ready,
+	}
+	require.Equal(t, expectedPolicyStatus, policy.Status)
+
+	///////////////////////////
+	// the user set the policy to monitor
+	///////////////////////////
+
+	// we should receive new violation in monitor mode so we convert them
+	podAViolationMonitor := podAViolation.withAction(policymode.MonitorString)
+	podBViolationMonitor := podBViolation.withAction(policymode.MonitorString)
+	violations = []ViolationRecord{
+		// The agent should send newest records first
+		podAViolationMonitor.withTimestamp(ts(20)),
+		podBViolationMonitor.withTimestamp(ts(21)),
+		podAViolationMonitor.withTimestamp(ts(22)),
+	}
+	policy.RecomputeStatus(nil, violations, ts(24))
+	expectedPolicyStatus = WorkloadPolicyStatus{
+		ViolationCount:       7,
+		ActiveViolationCount: 4,
+		Violations: []ViolationRecord{
+			podAViolationMonitor.withID(4).withTimestamp(ts(22)),
+			podBViolationMonitor.withID(5).withTimestamp(ts(21)),
+			podAViolation.withID(0).withTimestamp(ts(4)),
+			podBViolation.withID(2).withTimestamp(ts(3)),
+		},
+		ObservedGeneration: 7,
+		Phase:              Ready,
+	}
+	require.Equal(t, expectedPolicyStatus, policy.Status)
+
+	///////////////////////////
+	// the user adds the binary into the spec
+	///////////////////////////
+
+	policy.Spec.RulesByContainer[containerName].Executables.Allowed =
+		append(policy.Spec.RulesByContainer[containerName].Executables.Allowed, forgottenBinary)
+	policy.Generation = 8
+
+	// Some new violations comes in the meantime
+	violations = []ViolationRecord{
+		podAViolationMonitor.withTimestamp(ts(40)),
+		podBViolationMonitor.withTimestamp(ts(41)),
+	}
+	policy.RecomputeStatus(nil, violations, ts(42))
+	expectedPolicyStatus = WorkloadPolicyStatus{
+		ViolationCount:       9,
+		ActiveViolationCount: 0,
+		Violations:           []ViolationRecord{},
+		ObservedGeneration:   8,
+		Phase:                Ready,
+	}
+	require.Equal(t, expectedPolicyStatus, policy.Status)
+
+	///////////////////////////
+	// A real violation comes
+	///////////////////////////
+
+	violations = []ViolationRecord{
+		podAViolation.withTimestamp(ts(100)).withExecutable("/usr/bin/malware"),
+	}
+	policy.RecomputeStatus(nil, violations, ts(101))
+	expectedPolicyStatus = WorkloadPolicyStatus{
+		ViolationCount:       10,
+		ActiveViolationCount: 1,
+		Violations: []ViolationRecord{
+			podAViolation.withID(9).withTimestamp(ts(100)).withExecutable("/usr/bin/malware"),
+		},
+		ObservedGeneration: 8,
+		Phase:              Ready,
+	}
+	require.Equal(t, expectedPolicyStatus, policy.Status)
+
+	///////////////////////////
+	// The user acknowledges it
+	///////////////////////////
+
+	policy.Annotations[ViolationAcknowledgePrefix+"9"] = "acknowledged by the user"
+	acknowledgeTime := ts(120)
+	policy.RecomputeStatus(nil, nil, acknowledgeTime)
+	expectedPolicyStatus = WorkloadPolicyStatus{
+		ViolationCount:       10,
+		ActiveViolationCount: 0,
+		Violations:           []ViolationRecord{},
+		AcknowledgedViolations: []AcknowledgedViolationRecord{
+			{
+				Violation:      podAViolation.withID(9).withTimestamp(ts(100)).withExecutable("/usr/bin/malware"),
+				Reason:         "acknowledged by the user",
+				AcknowledgedAt: metav1.Time{Time: acknowledgeTime},
+			},
+		},
+		ObservedGeneration: 8,
+		Phase:              Ready,
+	}
+	require.Equal(t, expectedPolicyStatus, policy.Status)
 }

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -166,7 +166,7 @@ func (wp *WorkloadPolicy) RecomputeStatus(
 	// Merge scraped violations into the status.
 	// we will clear/acknowledge violations after the merge so that the status
 	// is coherent across syncs.
-	wp.Status.MergeScrapedViolations(scrapedViolations)
+	wp.Status.mergeScrapedViolations(scrapedViolations)
 
 	// Stale violations are violations for binaries that
 	// are now in the spec.

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -155,7 +155,7 @@ func (wp *WorkloadPolicy) RecomputeStatus(
 		return nil, errors.New("WorkloadPolicy is nil")
 	}
 
-	if err := wp.Status.ProcessPolicyNodeStatus(nodes); err != nil {
+	if err := wp.Status.processPolicyNodeStatus(nodes); err != nil {
 		return nil, fmt.Errorf(
 			"failed to compute node status for policy %s: %w",
 			wp.NamespacedName(),

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -173,7 +173,7 @@ func (wp *WorkloadPolicy) RecomputeStatus(
 	wp.clearAllowedViolations()
 
 	// Acknowledge any violations that have been acknowledged
-	acknowledged := wp.AcknowledgeViolationsFromAnnotations(metav1.Time{Time: now})
+	acknowledged := wp.acknowledgeViolationsFromAnnotations(metav1.Time{Time: now})
 
 	wp.Status.ActiveViolationCount = len(wp.Status.Violations)
 	wp.Status.ObservedGeneration = wp.Generation

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -78,13 +78,13 @@ type WorkloadPolicyStatus struct {
 	// updated in the same status write.
 	// +optional
 	ActiveViolationCount int `json:"activeViolationCount,omitempty"`
-	// violations is the list of the most recent violation records (max MaxViolationRecords).
+	// violations is the list of the most recent violation records (max maxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	// +optional
 	Violations []ViolationRecord `json:"violations,omitempty"`
 
 	// acknowledgedViolations is the list of the most recent violation records that are acknowledged
-	// by users (max MaxViolationRecords).
+	// by users (max maxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	// +optional
 	AcknowledgedViolations []AcknowledgedViolationRecord `json:"acknowledgedViolations,omitempty"`

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -143,6 +144,40 @@ func (wp *WorkloadPolicy) HasPromotedLabel(proposalName string) bool {
 		return false
 	}
 	return wp.Labels[PolicyPromotedFromLabelKey] == proposalName
+}
+
+func (wp *WorkloadPolicy) RecomputeStatus(
+	nodes []PolicyNodeStatus,
+	scrapedViolations []ViolationRecord,
+	now time.Time,
+) ([]AcknowledgedViolationRecord, error) {
+	if wp == nil {
+		return nil, errors.New("WorkloadPolicy is nil")
+	}
+
+	if err := wp.Status.ProcessPolicyNodeStatus(nodes); err != nil {
+		return nil, fmt.Errorf(
+			"failed to compute node status for policy %s: %w",
+			wp.NamespacedName(),
+			err,
+		)
+	}
+
+	// Merge scraped violations into the status.
+	// we will clear/acknowledge violations after the merge so that the status
+	// is coherent across syncs.
+	wp.Status.MergeScrapedViolations(scrapedViolations)
+
+	// Stale violations are violations for binaries that
+	// are now in the spec.
+	wp.ClearAllowed()
+
+	// Acknowledge any violations that have been acknowledged
+	acknowledged := wp.AcknowledgeViolationsFromAnnotations(metav1.Time{Time: now})
+
+	wp.Status.ActiveViolationCount = len(wp.Status.Violations)
+	wp.Status.ObservedGeneration = wp.Generation
+	return acknowledged, nil
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -170,7 +170,7 @@ func (wp *WorkloadPolicy) RecomputeStatus(
 
 	// Stale violations are violations for binaries that
 	// are now in the spec.
-	wp.ClearAllowed()
+	wp.clearAllowedViolations()
 
 	// Acknowledge any violations that have been acknowledged
 	acknowledged := wp.AcknowledgeViolationsFromAnnotations(metav1.Time{Time: now})

--- a/api/v1alpha1/workloadpolicyproposal_test.go
+++ b/api/v1alpha1/workloadpolicyproposal_test.go
@@ -1,22 +1,21 @@
-package v1alpha1_test
+package v1alpha1
 
 import (
 	"strconv"
 	"testing"
 
-	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestWorkloadPolicyProposalNamespacedName(t *testing.T) {
 	t.Run("nil proposal returns empty string", func(t *testing.T) {
-		var p *v1alpha1.WorkloadPolicyProposal
+		var p *WorkloadPolicyProposal
 		require.Empty(t, p.NamespacedName())
 	})
 
 	t.Run("returns namespace/name", func(t *testing.T) {
-		p := &v1alpha1.WorkloadPolicyProposal{
+		p := &WorkloadPolicyProposal{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "test-namespace",
 				Name:      "test-name",
@@ -39,19 +38,19 @@ func TestWorkloadPolicyProposalIsFull(t *testing.T) {
 		},
 		{
 			name:           "proposal below max is not full",
-			executables:    v1alpha1.PolicyProposalMaxExecutables - 1,
+			executables:    policyProposalMaxExecutables - 1,
 			expectedIsFull: false,
 		},
 		{
 			name:           "proposal at max is full",
-			executables:    v1alpha1.PolicyProposalMaxExecutables,
+			executables:    policyProposalMaxExecutables,
 			expectedIsFull: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := &v1alpha1.WorkloadPolicyProposal{}
+			p := &WorkloadPolicyProposal{}
 			for i := range tc.executables {
 				p.AddProcess("container", "/bin/exe"+strconv.Itoa(i))
 			}
@@ -118,7 +117,7 @@ func TestWorkloadPolicyProposalAddProcess(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			p := &v1alpha1.WorkloadPolicyProposal{}
+			p := &WorkloadPolicyProposal{}
 			for _, call := range tc.calls {
 				p.AddProcess(call.containerName, call.executable)
 			}

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	// PolicyProposalMaxExecutables defines the maximum number of executables that we can learn.
+	// policyProposalMaxExecutables defines the maximum number of executables that we can learn.
 	// This is a arbitrary number right now and can be fine-tuned or made configurable in the future.
-	PolicyProposalMaxExecutables = 100
+	policyProposalMaxExecutables = 100
 )
 
 // WorkloadPolicyProposalSpec defines the desired state of WorkloadPolicyProposal.
@@ -85,7 +85,7 @@ func (p *WorkloadPolicyProposal) HasPromotionLabel() bool {
 }
 
 func (p *WorkloadPolicyProposal) IsFull() bool {
-	return p.getExecutablesLength() >= PolicyProposalMaxExecutables
+	return p.getExecutablesLength() >= policyProposalMaxExecutables
 }
 
 func (p *WorkloadPolicyProposal) AddProcess(containerName string, executable string) {

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
@@ -86,7 +86,7 @@ spec:
               acknowledgedViolations:
                 description: |-
                   acknowledgedViolations is the list of the most recent violation records that are acknowledged
-                  by users (max MaxViolationRecords).
+                  by users (max maxViolationRecords).
                   Oldest entries are dropped when the limit is reached.
                 items:
                   properties:
@@ -224,7 +224,7 @@ spec:
                 type: integer
               violations:
                 description: |-
-                  violations is the list of the most recent violation records (max MaxViolationRecords).
+                  violations is the list of the most recent violation records (max maxViolationRecords).
                   Oldest entries are dropped when the limit is reached.
                 items:
                   description: ViolationRecord holds the details of a single policy

--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -369,10 +369,10 @@ consistent and may be temporarily outdated. + |  |
 | *`activeViolationCount`* __integer__ | activeViolationCount is the number of currently active (non-cleared) +
 violation records. It is always equal to len(Violations) and is +
 updated in the same status write. + |  | 
-| *`violations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-violationrecord[$$ViolationRecord$$] array__ | violations is the list of the most recent violation records (max MaxViolationRecords). +
+| *`violations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-violationrecord[$$ViolationRecord$$] array__ | violations is the list of the most recent violation records (max maxViolationRecords). +
 Oldest entries are dropped when the limit is reached. + |  | 
 | *`acknowledgedViolations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-acknowledgedviolationrecord[$$AcknowledgedViolationRecord$$] array__ | acknowledgedViolations is the list of the most recent violation records that are acknowledged +
-by users (max MaxViolationRecords). +
+by users (max maxViolationRecords). +
 Oldest entries are dropped when the limit is reached. + |  | 
 |===
 

--- a/internal/controller/workloadpolicystatus_helpers.go
+++ b/internal/controller/workloadpolicystatus_helpers.go
@@ -11,37 +11,8 @@ import (
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/loglevel"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func (r *WorkloadPolicyStatusSync) processPolicyStatus(
-	wp *v1alpha1.WorkloadPolicy,
-	nodes []v1alpha1.PolicyNodeStatus,
-	scrapedViolations []v1alpha1.ViolationRecord,
-	now metav1.Time,
-) ([]v1alpha1.AcknowledgedViolationRecord, error) {
-	if err := wp.Status.ProcessPolicyNodeStatus(nodes); err != nil {
-		return nil, fmt.Errorf(
-			"failed to compute node status for policy %s: %w",
-			wp.NamespacedName(),
-			err,
-		)
-	}
-
-	// Merge scraped violations into the status.
-	// we will clear/acknowledge violations after the merge so that the status
-	// is coherent across syncs.
-	wp.Status.MergeScrapedViolations(scrapedViolations)
-
-	wp.ClearAllowed()
-
-	acknowledged := wp.AcknowledgeViolationsFromAnnotations(now)
-
-	wp.Status.ActiveViolationCount = len(wp.Status.Violations)
-	wp.Status.ObservedGeneration = wp.Generation
-	return acknowledged, nil
-}
 
 // processWorkloadPolicy updates the wp.status and wp.annotation in order to acknowledge a violation.
 // NOTE: agent side ignores annotation changes and status change via predicate.GenerationChangedPredicate{}.
@@ -54,7 +25,7 @@ func (r *WorkloadPolicyStatusSync) processWorkloadPolicy(
 	patchBase := client.MergeFrom(wp.DeepCopy())
 	newPolicy := wp.DeepCopy()
 
-	acknowledged, err := r.processPolicyStatus(newPolicy, nodes, scrapedViolations, metav1.NewTime(time.Now()))
+	acknowledged, err := newPolicy.RecomputeStatus(nodes, scrapedViolations, time.Now())
 	if err != nil {
 		return err
 	}

--- a/internal/controller/workloadpolicystatus_test.go
+++ b/internal/controller/workloadpolicystatus_test.go
@@ -3,14 +3,12 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/grpcexporter"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/testutil"
-	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	pb "github.com/rancher-sandbox/runtime-enforcer/proto/agent/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -64,12 +62,6 @@ func (c *testAgentClient) ScrapeViolations(_ context.Context) ([]*pb.ViolationRe
 
 func (c *testAgentClient) Close() error {
 	return nil
-}
-
-// withID returns a copy of r with the given id.
-func withID(r v1alpha1.ViolationRecord, id int64) v1alpha1.ViolationRecord {
-	r.ID = id
-	return r
 }
 
 func TestGetViolationsByPolicy(t *testing.T) {
@@ -156,70 +148,4 @@ func TestGetViolationsByPolicy(t *testing.T) {
 		got := r.getViolationsByPolicy(context.Background(), nil)
 		require.Empty(t, got)
 	})
-}
-
-func TestBuildPolicyStatusClearanceFreesCapForNewViolations(t *testing.T) {
-	ns := "ns"
-	mode := policymode.MonitorString
-
-	// Fill existing violations to the cap. The first record (id=1) is for
-	// an executable that will be allowed, so it gets cleared and makes room.
-	existing := make([]v1alpha1.ViolationRecord, v1alpha1.MaxViolationRecords)
-	for i := range existing {
-		existing[i] = withID(v1alpha1.ViolationRecord{
-			Timestamp:      metav1.NewTime(time.Date(2026, 1, 1, 0, 0, i, 0, time.UTC)),
-			PodName:        fmt.Sprintf("pod-%d", i),
-			ContainerName:  "app",
-			ExecutablePath: fmt.Sprintf("/usr/bin/exe-%d", i),
-			NodeName:       "node-1",
-			Action:         "monitor",
-		}, int64(i+1))
-	}
-
-	wp := &v1alpha1.WorkloadPolicy{
-		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: ns},
-		Spec: v1alpha1.WorkloadPolicySpec{
-			Mode: mode,
-			RulesByContainer: map[string]*v1alpha1.WorkloadPolicyRules{
-				"app": {
-					Executables: v1alpha1.WorkloadPolicyExecutables{
-						Allowed: []string{"/usr/bin/exe-0"},
-					},
-				},
-			},
-		},
-		Status: v1alpha1.WorkloadPolicyStatus{
-			ViolationCount: int64(v1alpha1.MaxViolationRecords),
-			Violations:     existing,
-		},
-	}
-
-	// Add a brand-new violation that would have been dropped if the cap had
-	// not been freed by clearing exe-0.
-	removedViolation := existing[0]
-	newViolation := v1alpha1.ViolationRecord{
-		Timestamp:      metav1.NewTime(time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)),
-		PodName:        "pod-new",
-		ContainerName:  "app",
-		ExecutablePath: "/usr/bin/new-exe",
-		NodeName:       "node-2",
-		Action:         "monitor",
-	}
-
-	r := createTestWPStatusSync(t)
-
-	_, err := r.processPolicyStatus(wp, nil, []v1alpha1.ViolationRecord{newViolation}, metav1.NewTime(time.Now()))
-	status := wp.Status
-	require.NoError(t, err)
-	require.Len(t, status.Violations, v1alpha1.MaxViolationRecords,
-		"list should remain at the cap after clearance + merge")
-	require.Equal(t, int64(v1alpha1.MaxViolationRecords+1), status.ViolationCount,
-		"ViolationCount must account for the new observed violation")
-	require.Equal(t, v1alpha1.MaxViolationRecords, status.ActiveViolationCount,
-		"ActiveViolationCount must equal len(Violations)")
-
-	// exe-0 should be gone, /usr/bin/new-exe should be present.
-	newViolation.ID = int64(v1alpha1.MaxViolationRecords)
-	require.Contains(t, status.Violations, newViolation)
-	require.NotContains(t, status.Violations, removedViolation)
 }

--- a/pkg/generated/applyconfiguration/api/v1alpha1/workloadpolicystatus.go
+++ b/pkg/generated/applyconfiguration/api/v1alpha1/workloadpolicystatus.go
@@ -34,11 +34,11 @@ type WorkloadPolicyStatusApplyConfiguration struct {
 	// violation records. It is always equal to len(Violations) and is
 	// updated in the same status write.
 	ActiveViolationCount *int `json:"activeViolationCount,omitempty"`
-	// violations is the list of the most recent violation records (max MaxViolationRecords).
+	// violations is the list of the most recent violation records (max maxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	Violations []ViolationRecordApplyConfiguration `json:"violations,omitempty"`
 	// acknowledgedViolations is the list of the most recent violation records that are acknowledged
-	// by users (max MaxViolationRecords).
+	// by users (max maxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	AcknowledgedViolations []AcknowledgedViolationRecordApplyConfiguration `json:"acknowledgedViolations,omitempty"`
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -651,7 +651,7 @@ func schema_rancher_sandbox_runtime_enforcer_api_v1alpha1_WorkloadPolicyStatus(r
 					},
 					"violations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "violations is the list of the most recent violation records (max MaxViolationRecords). Oldest entries are dropped when the limit is reached.",
+							Description: "violations is the list of the most recent violation records (max maxViolationRecords). Oldest entries are dropped when the limit is reached.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -665,7 +665,7 @@ func schema_rancher_sandbox_runtime_enforcer_api_v1alpha1_WorkloadPolicyStatus(r
 					},
 					"acknowledgedViolations": {
 						SchemaProps: spec.SchemaProps{
-							Description: "acknowledgedViolations is the list of the most recent violation records that are acknowledged by users (max MaxViolationRecords). Oldest entries are dropped when the limit is reached.",
+							Description: "acknowledgedViolations is the list of the most recent violation records that are acknowledged by users (max maxViolationRecords). Oldest entries are dropped when the limit is reached.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part of https://github.com/rancher-sandbox/runtime-enforcer/issues/725.
In this PR i moved the processPolicyStatus method to v1alpha1 package.
as you can see we can avoid to export a lot of things, it is enough to export processPolicyStatus renamed into `RecomputeStatus`

**Which issue(s) this PR fixes**

fixes #725 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
