### PR TITLE
feat: show violationCount and activeViolationCount in kubectl get

### DIFF
--- a/api/v1alpha1/workloadpolicy_types.go
+++ b/api/v1alpha1/workloadpolicy_types.go
@@ -71,13 +71,15 @@ type WorkloadPolicyStatus struct {
 	// been trimmed out of Violations or cleared because the executable
 	// was later added to an allowlist. It is not guaranteed to be strongly
 	// consistent and may be temporarily outdated.
+	// +kubebuilder:default=0
 	// +optional
-	ViolationCount int64 `json:"violationCount,omitempty"`
+	ViolationCount int64 `json:"violationCount"`
 	// activeViolationCount is the number of currently active (non-cleared)
 	// violation records. It is always equal to len(Violations) and is
 	// updated in the same status write.
+	// +kubebuilder:default=0
 	// +optional
-	ActiveViolationCount int `json:"activeViolationCount,omitempty"`
+	ActiveViolationCount int `json:"activeViolationCount"`
 	// violations is the list of the most recent violation records (max maxViolationRecords).
 	// Oldest entries are dropped when the limit is reached.
 	// +optional
@@ -94,6 +96,8 @@ type WorkloadPolicyStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="Active Violations",type=string,JSONPath=`.status.activeViolationCount`
+// +kubebuilder:printcolumn:name="Total Violations",type=string,JSONPath=`.status.violationCount`
 // +kubebuilder:resource:categories={rancher-security},singular="workloadpolicy",path="workloadpolicies",scope="Namespaced",shortName={wp}
 // +kubebuilder:metadata:annotations="helm.sh/resource-policy=keep"
 // +genclient

--- a/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
+++ b/charts/runtime-enforcer/templates/crd/security.rancher.io_workloadpolicies.yaml
@@ -26,6 +26,12 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.activeViolationCount
+      name: Active Violations
+      type: string
+    - jsonPath: .status.violationCount
+      name: Total Violations
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -165,6 +171,7 @@ spec:
                   type: object
                 type: array
               activeViolationCount:
+                default: 0
                 description: |-
                   activeViolationCount is the number of currently active (non-cleared)
                   violation records. It is always equal to len(Violations) and is
@@ -214,6 +221,7 @@ spec:
                   is transitioning mode.
                 type: integer
               violationCount:
+                default: 0
                 description: |-
                   violationCount is the total number of unique violation records
                   ever observed for this policy, including those that have already

--- a/docs/crd.adoc
+++ b/docs/crd.adoc
@@ -365,10 +365,10 @@ Required: \{} +
 ever observed for this policy, including those that have already +
 been trimmed out of Violations or cleared because the executable +
 was later added to an allowlist. It is not guaranteed to be strongly +
-consistent and may be temporarily outdated. + |  | 
+consistent and may be temporarily outdated. + | 0 | 
 | *`activeViolationCount`* __integer__ | activeViolationCount is the number of currently active (non-cleared) +
 violation records. It is always equal to len(Violations) and is +
-updated in the same status write. + |  | 
+updated in the same status write. + | 0 | 
 | *`violations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-violationrecord[$$ViolationRecord$$] array__ | violations is the list of the most recent violation records (max maxViolationRecords). +
 Oldest entries are dropped when the limit is reached. + |  | 
 | *`acknowledgedViolations`* __xref:{anchor_prefix}-github-com-rancher-sandbox-runtime-enforcer-api-v1alpha1-acknowledgedviolationrecord[$$AcknowledgedViolationRecord$$] array__ | acknowledgedViolations is the list of the most recent violation records that are acknowledged +

--- a/pkg/generated/applyconfiguration/internal/internal.go
+++ b/pkg/generated/applyconfiguration/internal/internal.go
@@ -166,6 +166,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: activeViolationCount
       type:
         scalar: numeric
+      default: 0
     - name: failedNodes
       type:
         scalar: numeric
@@ -198,6 +199,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: violationCount
       type:
         scalar: numeric
+      default: 0
     - name: violations
       type:
         list:

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -638,6 +638,7 @@ func schema_rancher_sandbox_runtime_enforcer_api_v1alpha1_WorkloadPolicyStatus(r
 					"violationCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "violationCount is the total number of unique violation records ever observed for this policy, including those that have already been trimmed out of Violations or cleared because the executable was later added to an allowlist. It is not guaranteed to be strongly consistent and may be temporarily outdated.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -645,6 +646,7 @@ func schema_rancher_sandbox_runtime_enforcer_api_v1alpha1_WorkloadPolicyStatus(r
 					"activeViolationCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "activeViolationCount is the number of currently active (non-cleared) violation records. It is always equal to len(Violations) and is updated in the same status write.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

Add two printcolumn tags to wp resource so we can see these extra information via kubectl get. 

This PR also contains a fix to prevent violation ID from keeping increasing due to a noisy pod/container. 

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
