### PR TITLE
refactor: package name and couple of helper functions

### DIFF
--- a/internal/kubectlplugin/policy_ack.go
+++ b/internal/kubectlplugin/policy_ack.go
@@ -10,11 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/util/completion"
 )
 
@@ -117,7 +115,7 @@ func runPolicyAck(
 	stdout, stderr io.Writer,
 ) error {
 	var reason string
-	var violation apiv1alpha1.ViolationRecord
+	var violation v1alpha1.ViolationRecord
 
 	policy, err := getWorkloadPolicy(ctx, client, opts.Namespace, opts.PolicyName)
 	if err != nil {
@@ -149,7 +147,7 @@ func runPolicyAck(
 		printPolicyAckDryRun(stdout, opts, policy, violation, annotationKey, reason)
 	}
 
-	if err = updateAckWorkloadPolicy(ctx, client, opts.Namespace, policy, opts.DryRun); err != nil {
+	if err = updateWorkloadPolicy(ctx, client, opts.Namespace, policy, opts.DryRun); err != nil {
 		return err
 	}
 
@@ -168,28 +166,8 @@ func runPolicyAck(
 	return nil
 }
 
-func getWorkloadPolicy(
-	ctx context.Context,
-	client securityclient.SecurityV1alpha1Interface,
-	namespace, name string,
-) (*apiv1alpha1.WorkloadPolicy, error) {
-	policy, err := client.WorkloadPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, fmt.Errorf("workloadpolicy %q not found in namespace %q", name, namespace)
-		}
-		return nil, fmt.Errorf(
-			"failed to get WorkloadPolicy %q in namespace %q: %w",
-			name,
-			namespace,
-			err,
-		)
-	}
-	return policy, nil
-}
-
 func applyAckAnnotation(
-	policy *apiv1alpha1.WorkloadPolicy,
+	policy *v1alpha1.WorkloadPolicy,
 	violationID int64,
 	reason string,
 ) (string, bool) {
@@ -210,8 +188,8 @@ func applyAckAnnotation(
 func printPolicyAckDryRun(
 	out io.Writer,
 	opts *policyAckOptions,
-	policy *apiv1alpha1.WorkloadPolicy,
-	violation apiv1alpha1.ViolationRecord,
+	policy *v1alpha1.WorkloadPolicy,
+	violation v1alpha1.ViolationRecord,
 	annotationKey, reason string,
 ) {
 	fmt.Fprintf(
@@ -229,37 +207,6 @@ func printPolicyAckDryRun(
 		violation.ContainerName,
 		violation.PodName,
 	)
-}
-
-func updateAckWorkloadPolicy(
-	ctx context.Context,
-	client securityclient.SecurityV1alpha1Interface,
-	namespace string,
-	policy *apiv1alpha1.WorkloadPolicy,
-	dryRun bool,
-) error {
-	updateOptions := metav1.UpdateOptions{}
-	if dryRun {
-		updateOptions.DryRun = []string{metav1.DryRunAll}
-	}
-
-	if _, err := client.WorkloadPolicies(namespace).Update(ctx, policy, updateOptions); err != nil {
-		if apierrors.IsConflict(err) {
-			return fmt.Errorf(
-				"WorkloadPolicy %q in namespace %q was modified concurrently",
-				policy.Name,
-				policy.Namespace,
-			)
-		}
-		return fmt.Errorf(
-			"failed to update WorkloadPolicy %q in namespace %q: %w",
-			policy.Name,
-			policy.Namespace,
-			err,
-		)
-	}
-
-	return nil
 }
 
 func resolveAckReason(opts *policyAckOptions, in io.Reader, errOut io.Writer) (string, error) {
@@ -284,19 +231,19 @@ func resolveAckReason(opts *policyAckOptions, in io.Reader, errOut io.Writer) (s
 	return reason, nil
 }
 
-func findViolationByID(violations []apiv1alpha1.ViolationRecord, id int64) (apiv1alpha1.ViolationRecord, error) {
+func findViolationByID(violations []v1alpha1.ViolationRecord, id int64) (v1alpha1.ViolationRecord, error) {
 	for _, violation := range violations {
 		if violation.ID == id {
 			return violation, nil
 		}
 	}
 
-	return apiv1alpha1.ViolationRecord{}, fmt.Errorf(
+	return v1alpha1.ViolationRecord{}, fmt.Errorf(
 		"violation id %d not found in status.violations",
 		id,
 	)
 }
 
 func violationAcknowledgeAnnotationKey(id int64) string {
-	return apiv1alpha1.ViolationAcknowledgePrefix + strconv.FormatInt(id, 10)
+	return v1alpha1.ViolationAcknowledgePrefix + strconv.FormatInt(id, 10)
 }

--- a/internal/kubectlplugin/policy_ack_test.go
+++ b/internal/kubectlplugin/policy_ack_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	fakeclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/fake"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -22,15 +22,15 @@ func TestRunPolicyAck(t *testing.T) {
 		name = "test-policy"
 	)
 
-	makePolicy := func(annotations map[string]string) *apiv1alpha1.WorkloadPolicy {
-		return &apiv1alpha1.WorkloadPolicy{
+	makePolicy := func(annotations map[string]string) *v1alpha1.WorkloadPolicy {
+		return &v1alpha1.WorkloadPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        name,
 				Namespace:   ns,
 				Annotations: annotations,
 			},
-			Status: apiv1alpha1.WorkloadPolicyStatus{
-				Violations: []apiv1alpha1.ViolationRecord{
+			Status: v1alpha1.WorkloadPolicyStatus{
+				Violations: []v1alpha1.ViolationRecord{
 					{
 						ID:             1,
 						ContainerName:  "app",
@@ -50,7 +50,7 @@ func TestRunPolicyAck(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		policy         *apiv1alpha1.WorkloadPolicy
+		policy         *v1alpha1.WorkloadPolicy
 		violationID    int64
 		reason         string
 		reasonSet      bool
@@ -191,30 +191,30 @@ func TestRunPolicyAck(t *testing.T) {
 func TestCompletePolicyAckValidArgs(t *testing.T) {
 	t.Parallel()
 
-	testWorkloadPolicy := &apiv1alpha1.WorkloadPolicy{
+	testWorkloadPolicy := &v1alpha1.WorkloadPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
 			Namespace: "test",
 		},
-		Status: apiv1alpha1.WorkloadPolicyStatus{
-			Violations: []apiv1alpha1.ViolationRecord{
+		Status: v1alpha1.WorkloadPolicyStatus{
+			Violations: []v1alpha1.ViolationRecord{
 				{ID: 1, ContainerName: "app", ExecutablePath: "/bin/mv"},
 				{ID: 2, ContainerName: "app", ExecutablePath: "/bin/ls"},
 			},
 		},
 	}
 
-	emptyWorkloadPolicy := &apiv1alpha1.WorkloadPolicy{
+	emptyWorkloadPolicy := &v1alpha1.WorkloadPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
 			Namespace: "test",
 		},
-		Status: apiv1alpha1.WorkloadPolicyStatus{},
+		Status: v1alpha1.WorkloadPolicyStatus{},
 	}
 
 	tests := []struct {
 		name              string
-		policy            *apiv1alpha1.WorkloadPolicy
+		policy            *v1alpha1.WorkloadPolicy
 		args              []string
 		expectedCompletes []string
 	}{

--- a/internal/kubectlplugin/policy_exec.go
+++ b/internal/kubectlplugin/policy_exec.go
@@ -8,11 +8,9 @@ import (
 	"slices"
 	"strconv"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/completion"
 )
@@ -168,17 +166,9 @@ func runPolicyExec(
 	opts *policyExecOptions,
 	out io.Writer,
 ) error {
-	policy, err := client.WorkloadPolicies(opts.Namespace).Get(ctx, opts.PolicyName, metav1.GetOptions{})
+	policy, err := getWorkloadPolicy(ctx, client, opts.Namespace, opts.PolicyName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("workloadpolicy %q not found in namespace %q", opts.PolicyName, opts.Namespace)
-		}
-		return fmt.Errorf(
-			"failed to get WorkloadPolicy %q in namespace %q: %w",
-			opts.PolicyName,
-			opts.Namespace,
-			err,
-		)
+		return err
 	}
 
 	changed, err := applyExecutablesToPolicy(policy.Spec.RulesByContainer, opts)
@@ -214,7 +204,7 @@ func runPolicyExec(
 		)
 	}
 
-	if err = updateWorkloadPolicy(ctx, client, opts, policy); err != nil {
+	if err = updateWorkloadPolicy(ctx, client, opts.Namespace, policy, opts.DryRun); err != nil {
 		return err
 	}
 
@@ -229,7 +219,7 @@ func runPolicyExec(
 }
 
 func applyExecutablesToPolicy(
-	rulesByContainer map[string]*apiv1alpha1.WorkloadPolicyRules,
+	rulesByContainer map[string]*v1alpha1.WorkloadPolicyRules,
 	opts *policyExecOptions,
 ) (bool, error) {
 	if rulesByContainer == nil {
@@ -242,7 +232,7 @@ func applyExecutablesToPolicy(
 	}
 
 	if rules == nil {
-		rules = &apiv1alpha1.WorkloadPolicyRules{}
+		rules = &v1alpha1.WorkloadPolicyRules{}
 		rulesByContainer[opts.ContainerName] = rules
 	}
 
@@ -294,35 +284,4 @@ func denyExecutables(executables []string, denied []string) ([]string, bool) {
 	}
 
 	return newExecutables, changed
-}
-
-func updateWorkloadPolicy(
-	ctx context.Context,
-	client securityclient.SecurityV1alpha1Interface,
-	opts *policyExecOptions,
-	policy *apiv1alpha1.WorkloadPolicy,
-) error {
-	updateOptions := metav1.UpdateOptions{}
-	if opts.DryRun {
-		updateOptions.DryRun = []string{metav1.DryRunAll}
-	}
-
-	if _, err := client.WorkloadPolicies(opts.Namespace).
-		Update(ctx, policy, updateOptions); err != nil {
-		if apierrors.IsConflict(err) {
-			return fmt.Errorf(
-				"WorkloadPolicy %q in namespace %q was modified concurrently",
-				policy.Name,
-				policy.Namespace,
-			)
-		}
-		return fmt.Errorf(
-			"failed to update WorkloadPolicy %q in namespace %q: %w",
-			policy.Name,
-			policy.Namespace,
-			err,
-		)
-	}
-
-	return nil
 }

--- a/internal/kubectlplugin/policy_exec_test.go
+++ b/internal/kubectlplugin/policy_exec_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"testing"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	fakeclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/fake"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -73,15 +73,15 @@ func TestRunPolicyExec(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			policy := &apiv1alpha1.WorkloadPolicy{
+			policy := &v1alpha1.WorkloadPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: ns,
 				},
-				Spec: apiv1alpha1.WorkloadPolicySpec{
-					RulesByContainer: map[string]*apiv1alpha1.WorkloadPolicyRules{
+				Spec: v1alpha1.WorkloadPolicySpec{
+					RulesByContainer: map[string]*v1alpha1.WorkloadPolicyRules{
 						"app": {
-							Executables: apiv1alpha1.WorkloadPolicyExecutables{
+							Executables: v1alpha1.WorkloadPolicyExecutables{
 								Allowed: append([]string(nil), tt.initialList...),
 							},
 						},
@@ -126,28 +126,28 @@ func TestRunPolicyExec(t *testing.T) {
 func TestCompletePolicyExecValidArgs(t *testing.T) {
 	t.Parallel()
 
-	testWorkloadPolicy := &apiv1alpha1.WorkloadPolicy{
+	testWorkloadPolicy := &v1alpha1.WorkloadPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
 			Namespace: "test",
 		},
-		Spec: apiv1alpha1.WorkloadPolicySpec{
-			RulesByContainer: map[string]*apiv1alpha1.WorkloadPolicyRules{
+		Spec: v1alpha1.WorkloadPolicySpec{
+			RulesByContainer: map[string]*v1alpha1.WorkloadPolicyRules{
 				"app": {
-					Executables: apiv1alpha1.WorkloadPolicyExecutables{
+					Executables: v1alpha1.WorkloadPolicyExecutables{
 						Allowed: []string{"/bin/ls", "/bin/cat"},
 					},
 				},
 				"db": {
-					Executables: apiv1alpha1.WorkloadPolicyExecutables{
+					Executables: v1alpha1.WorkloadPolicyExecutables{
 						Allowed: []string{"/bin/ps", "/bin/top"},
 					},
 				},
 			},
 		},
-		Status: apiv1alpha1.WorkloadPolicyStatus{
+		Status: v1alpha1.WorkloadPolicyStatus{
 			ObservedGeneration: 1,
-			Violations: []apiv1alpha1.ViolationRecord{
+			Violations: []v1alpha1.ViolationRecord{
 				{
 					ContainerName:  "app",
 					ExecutablePath: "/bin/mv",
@@ -160,19 +160,19 @@ func TestCompletePolicyExecValidArgs(t *testing.T) {
 		},
 	}
 
-	emptyWorkloadPolicy := &apiv1alpha1.WorkloadPolicy{
+	emptyWorkloadPolicy := &v1alpha1.WorkloadPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-policy",
 			Namespace: "test",
 		},
-		Spec:   apiv1alpha1.WorkloadPolicySpec{},
-		Status: apiv1alpha1.WorkloadPolicyStatus{},
+		Spec:   v1alpha1.WorkloadPolicySpec{},
+		Status: v1alpha1.WorkloadPolicyStatus{},
 	}
 
 	tests := []struct {
 		name              string
 		action            policyExecAction
-		policy            *apiv1alpha1.WorkloadPolicy
+		policy            *v1alpha1.WorkloadPolicy
 		args              []string
 		expectedCompletes []string
 	}{

--- a/internal/kubectlplugin/policy_mode.go
+++ b/internal/kubectlplugin/policy_mode.go
@@ -8,8 +8,6 @@ import (
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/util/completion"
 )
 
@@ -88,17 +86,9 @@ func runPolicyModeSet(
 	opts *policyModeOptions,
 	out io.Writer,
 ) error {
-	policy, err := client.WorkloadPolicies(opts.Namespace).Get(ctx, opts.PolicyName, metav1.GetOptions{})
+	policy, err := getWorkloadPolicy(ctx, client, opts.Namespace, opts.PolicyName)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("workloadpolicy %q not found in namespace %q", opts.PolicyName, opts.Namespace)
-		}
-		return fmt.Errorf(
-			"failed to get WorkloadPolicy %q in namespace %q: %w",
-			opts.PolicyName,
-			opts.Namespace,
-			err,
-		)
+		return err
 	}
 
 	currentMode := policy.Spec.Mode
@@ -115,7 +105,6 @@ func runPolicyModeSet(
 		return nil
 	}
 
-	updateOptions := metav1.UpdateOptions{}
 	if opts.DryRun {
 		fmt.Fprintf(
 			out,
@@ -124,26 +113,12 @@ func runPolicyModeSet(
 			policy.Namespace,
 			targetMode,
 		)
-		updateOptions.DryRun = []string{metav1.DryRunAll}
 	}
 
 	policy.Spec.Mode = targetMode
 
-	if _, err = client.WorkloadPolicies(opts.Namespace).
-		Update(ctx, policy, updateOptions); err != nil {
-		if apierrors.IsConflict(err) {
-			return fmt.Errorf(
-				"WorkloadPolicy %q in namespace %q was modified concurrently",
-				policy.Name,
-				policy.Namespace,
-			)
-		}
-		return fmt.Errorf(
-			"failed to update WorkloadPolicy %q in namespace %q: %w",
-			policy.Name,
-			policy.Namespace,
-			err,
-		)
+	if err = updateWorkloadPolicy(ctx, client, opts.Namespace, policy, opts.DryRun); err != nil {
+		return err
 	}
 
 	fmt.Fprintf(

--- a/internal/kubectlplugin/policy_show_protection.go
+++ b/internal/kubectlplugin/policy_show_protection.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"strings"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/podworkload"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
@@ -131,17 +131,17 @@ func collectPolicyProtectionRows(
 
 func buildWorkloadProtectionRows(
 	pods []corev1.Pod,
-	workloadPolicies []apiv1alpha1.WorkloadPolicy,
+	workloadPolicies []v1alpha1.WorkloadPolicy,
 ) []workloadProtectionRow {
 	// we need to use policy namespace+name to have a unique key.
-	policyByNamespacedName := make(map[types.NamespacedName]apiv1alpha1.WorkloadPolicy, len(workloadPolicies))
+	policyByNamespacedName := make(map[types.NamespacedName]v1alpha1.WorkloadPolicy, len(workloadPolicies))
 	for _, policy := range workloadPolicies {
 		policyByNamespacedName[types.NamespacedName{Namespace: policy.Namespace, Name: policy.Name}] = policy
 	}
 
 	rowsByKey := map[types.NamespacedName]workloadProtectionRow{}
 	for _, pod := range pods {
-		policyName := pod.Labels[apiv1alpha1.PolicyLabelKey]
+		policyName := pod.Labels[v1alpha1.PolicyLabelKey]
 		// if there is no policy label we don't consider the pod
 		if policyName == "" {
 			continue

--- a/internal/kubectlplugin/policy_show_protection_test.go
+++ b/internal/kubectlplugin/policy_show_protection_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/types/workloadkind"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 	tests := []struct {
 		name     string
 		pods     []corev1.Pod
-		policies []apiv1alpha1.WorkloadPolicy
+		policies []v1alpha1.WorkloadPolicy
 		expected []workloadProtectionRow
 	}{
 		{
@@ -47,8 +47,8 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 						Name:      "opensuse-deployment-6469c647b5-2ftx7",
 						Namespace: namespaceA,
 						Labels: map[string]string{
-							apiv1alpha1.PolicyLabelKey: policyName,
-							podTemplateHashLabel:       "6469c647b5",
+							v1alpha1.PolicyLabelKey: policyName,
+							podTemplateHashLabel:    "6469c647b5",
 						},
 					},
 				},
@@ -57,17 +57,17 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 						Name:      "opensuse-deployment-6469c647b5-tjssz",
 						Namespace: namespaceA,
 						Labels: map[string]string{
-							apiv1alpha1.PolicyLabelKey: policyName,
-							podTemplateHashLabel:       "6469c647b5",
+							v1alpha1.PolicyLabelKey: policyName,
+							podTemplateHashLabel:    "6469c647b5",
 						},
 					},
 				},
 			},
-			policies: []apiv1alpha1.WorkloadPolicy{
+			policies: []v1alpha1.WorkloadPolicy{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: namespaceA},
-					Spec:       apiv1alpha1.WorkloadPolicySpec{Mode: policymode.ProtectString},
-					Status:     apiv1alpha1.WorkloadPolicyStatus{Phase: apiv1alpha1.Ready},
+					Spec:       v1alpha1.WorkloadPolicySpec{Mode: policymode.ProtectString},
+					Status:     v1alpha1.WorkloadPolicyStatus{Phase: v1alpha1.Ready},
 				},
 			},
 			expected: []workloadProtectionRow{
@@ -76,7 +76,7 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 					Kind:     workloadkind.Deployment.String(),
 					Policy:   policyName,
 					Mode:     modeToUpper(policymode.ProtectString),
-					Status:   string(apiv1alpha1.Ready),
+					Status:   string(v1alpha1.Ready),
 				},
 			},
 		},
@@ -88,8 +88,8 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 						Name:      "opensuse-deployment-6469c647b5-2ftx7",
 						Namespace: namespaceA,
 						Labels: map[string]string{
-							apiv1alpha1.PolicyLabelKey: policyName,
-							podTemplateHashLabel:       "6469c647b5",
+							v1alpha1.PolicyLabelKey: policyName,
+							podTemplateHashLabel:    "6469c647b5",
 						},
 					},
 				},
@@ -113,7 +113,7 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 						Name:      "pod-a",
 						Namespace: namespaceA,
 						Labels: map[string]string{
-							apiv1alpha1.PolicyLabelKey: policyName,
+							v1alpha1.PolicyLabelKey: policyName,
 						},
 					},
 				},
@@ -122,21 +122,21 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 						Name:      "pod-b",
 						Namespace: namespaceB,
 						Labels: map[string]string{
-							apiv1alpha1.PolicyLabelKey: policyName,
+							v1alpha1.PolicyLabelKey: policyName,
 						},
 					},
 				},
 			},
-			policies: []apiv1alpha1.WorkloadPolicy{
+			policies: []v1alpha1.WorkloadPolicy{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: namespaceA},
-					Spec:       apiv1alpha1.WorkloadPolicySpec{Mode: policymode.MonitorString},
-					Status:     apiv1alpha1.WorkloadPolicyStatus{Phase: apiv1alpha1.Ready},
+					Spec:       v1alpha1.WorkloadPolicySpec{Mode: policymode.MonitorString},
+					Status:     v1alpha1.WorkloadPolicyStatus{Phase: v1alpha1.Ready},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: policyName, Namespace: namespaceB},
-					Spec:       apiv1alpha1.WorkloadPolicySpec{Mode: policymode.ProtectString},
-					Status:     apiv1alpha1.WorkloadPolicyStatus{Phase: apiv1alpha1.Failed},
+					Spec:       v1alpha1.WorkloadPolicySpec{Mode: policymode.ProtectString},
+					Status:     v1alpha1.WorkloadPolicyStatus{Phase: v1alpha1.Failed},
 				},
 			},
 			expected: []workloadProtectionRow{
@@ -145,14 +145,14 @@ func TestBuildWorkloadProtectionRows(t *testing.T) {
 					Kind:     workloadkind.Pod.String(),
 					Policy:   policyName,
 					Mode:     modeToUpper(policymode.MonitorString),
-					Status:   string(apiv1alpha1.Ready),
+					Status:   string(v1alpha1.Ready),
 				},
 				{
 					Workload: types.NamespacedName{Namespace: namespaceB, Name: "pod-b"}.String(),
 					Kind:     workloadkind.Pod.String(),
 					Policy:   policyName,
 					Mode:     modeToUpper(policymode.ProtectString),
-					Status:   string(apiv1alpha1.Failed),
+					Status:   string(v1alpha1.Failed),
 				},
 			},
 		},
@@ -176,7 +176,7 @@ func TestRenderPolicyProtection(t *testing.T) {
 		Kind:     workloadkind.Deployment.String(),
 		Policy:   policyName,
 		Mode:     modeToUpper(policymode.ProtectString),
-		Status:   string(apiv1alpha1.Ready),
+		Status:   string(v1alpha1.Ready),
 	}}
 
 	t.Run("validate json", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestRenderPolicyProtection(t *testing.T) {
 		require.Equal(t, policyName, decoded[0]["policy"])
 		require.Equal(t, workloadkind.Deployment.String(), decoded[0]["kind"])
 		require.Equal(t, modeToUpper(policymode.ProtectString), decoded[0]["mode"])
-		require.Equal(t, string(apiv1alpha1.Ready), decoded[0]["status"])
+		require.Equal(t, string(v1alpha1.Ready), decoded[0]["status"])
 	})
 
 	t.Run("validate table", func(t *testing.T) {
@@ -211,6 +211,6 @@ func TestRenderPolicyProtection(t *testing.T) {
 		require.Contains(t, output, policyName)
 		require.Contains(t, output, workloadkind.Deployment.String())
 		require.Contains(t, output, modeToUpper(policymode.ProtectString))
-		require.Contains(t, output, string(apiv1alpha1.Ready))
+		require.Contains(t, output, string(v1alpha1.Ready))
 	})
 }

--- a/internal/kubectlplugin/proposal_promote.go
+++ b/internal/kubectlplugin/proposal_promote.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	apiv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -157,7 +157,7 @@ func waitForWorkloadPolicy(
 	ctx context.Context,
 	client securityclient.SecurityV1alpha1Interface,
 	namespace, name string,
-) (*apiv1alpha1.WorkloadPolicy, error) {
+) (*v1alpha1.WorkloadPolicy, error) {
 	ticker := time.NewTicker(defaultPollInterval)
 	defer ticker.Stop()
 

--- a/internal/kubectlplugin/utils.go
+++ b/internal/kubectlplugin/utils.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/client-go/kubernetes"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -139,4 +142,55 @@ func withRuntimeEnforcerAndCoreClient(
 	defer cancel()
 
 	return subcommand(ctx, securityClient, kubeClient.CoreV1())
+}
+
+func getWorkloadPolicy(
+	ctx context.Context,
+	client securityclient.SecurityV1alpha1Interface,
+	namespace, name string,
+) (*v1alpha1.WorkloadPolicy, error) {
+	policy, err := client.WorkloadPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("workloadpolicy %q not found in namespace %q", name, namespace)
+		}
+		return nil, fmt.Errorf(
+			"failed to get WorkloadPolicy %q in namespace %q: %w",
+			name,
+			namespace,
+			err,
+		)
+	}
+	return policy, nil
+}
+
+func updateWorkloadPolicy(
+	ctx context.Context,
+	client securityclient.SecurityV1alpha1Interface,
+	namespace string,
+	policy *v1alpha1.WorkloadPolicy,
+	dryRun bool,
+) error {
+	updateOptions := metav1.UpdateOptions{}
+	if dryRun {
+		updateOptions.DryRun = []string{metav1.DryRunAll}
+	}
+
+	if _, err := client.WorkloadPolicies(namespace).Update(ctx, policy, updateOptions); err != nil {
+		if apierrors.IsConflict(err) {
+			return fmt.Errorf(
+				"WorkloadPolicy %q in namespace %q was modified concurrently",
+				policy.Name,
+				policy.Namespace,
+			)
+		}
+		return fmt.Errorf(
+			"failed to update WorkloadPolicy %q in namespace %q: %w",
+			policy.Name,
+			policy.Namespace,
+			err,
+		)
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

- Standardize the kubectl plugin API import to use the package name v1alpha1 instead of the apiv1alpha1 alias.
- Extract shared getWorkloadPolicy and updateWorkloadPolicy helpers into utils.go and reuse them from policy ack, exec, and mode commands.

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
