### PR TITLE
docs: use `security.rancher.io/promote` where needed

### DIFF
--- a/docs/installation/quickstart.adoc
+++ b/docs/installation/quickstart.adoc
@@ -173,10 +173,10 @@ Some notes on this proposal:
 == WorkloadPolicy (monitor mode)
 
 This proposal looks reasonable for our Deployment, so the next step is converting it into a definitive policy.
-To do that, we label the `WorkloadPolicyProposal` with the `security.rancher.io/policy-ready` label set to `true`.
+To do that, we label the `WorkloadPolicyProposal` with the `security.rancher.io/promote` label set to `true`.
 
 ```bash
-kubectl label workloadpolicyproposals.security.rancher.io deploy-opensuse-deployment security.rancher.io/policy-ready=true
+kubectl label workloadpolicyproposals.security.rancher.io deploy-opensuse-deployment security.rancher.io/promote=true
 ```
 
 You can also use the kubectl plugin to perform the same step:

--- a/docs/kubectl_plugin.adoc
+++ b/docs/kubectl_plugin.adoc
@@ -58,7 +58,7 @@ sudo mv kubectl_complete-runtime_enforcer /usr/local/bin/
 
 === Promote a proposal (Learn → Monitor)
 
-Promoting a `WorkloadPolicyProposal` sets the `security.rancher.io/policy-ready=true` label and lets the controller create a `WorkloadPolicy`.
+Promoting a `WorkloadPolicyProposal` sets the `security.rancher.io/promote=true` label and lets the controller create a `WorkloadPolicy`.
 
 *Plugin:*
 

--- a/docs/phases.adoc
+++ b/docs/phases.adoc
@@ -26,12 +26,12 @@ Operationally, if you want complete proposals, enable learning first and then *(
 ** Ensure learning is enabled on some namespaces: `values.learning.namespaceSelector`
 ** No per-workload configuration is required to start generating proposals (proposals are created as exec events are observed).
 * *Leave*
-** Mark the corresponding proposal as ready by setting the label: `security.rancher.io/policy-ready=true`
+** Mark the corresponding proposal as ready by setting the label: `security.rancher.io/promote=true`
 ** Alternatively, use the kubectl plugin: `kubectl runtime-enforcer proposal promote <PROPOSAL_NAME>`.
 ** This triggers creation of a `WorkloadPolicy` (defaulting to `mode: monitor`), with the `workloadpolicy.security.rancher.io/promoted-from` label set so the promotion relationship is explicit.
 ** The `WorkloadPolicyProposal` object will be deleted after the promotion. Under rare conditions, caches might not be immediately updated, causing the `WorkloadPolicyProposal` to be created again. In those cases, a periodic cleanup will remove the leftover proposals.
 
-NOTE: If you create a `WorkloadPolicy` manually without that promotion relationship (no `security.rancher.io/policy-ready` label created in `WorkloadPolicyProposal`), the proposal is *not* removed by that flow. You must delete the `WorkloadPolicyProposal` manually.
+NOTE: If you create a `WorkloadPolicy` manually without that promotion relationship (no `security.rancher.io/promote` label created in `WorkloadPolicyProposal`), the proposal is *not* removed by that flow. You must delete the `WorkloadPolicyProposal` manually.
 
 === CRDs created/updated during this phase
 
@@ -67,7 +67,7 @@ WARNING: By default in the runtime-enforcer Helm chart, pods with a non-existing
 
 * *Leave*
 ** *Monitor → Protect*: update the `WorkloadPolicy` and set `.spec.mode: protect` (or `kubectl runtime-enforcer policy protect <POLICY_NAME>`).
-** *Monitor → Learn*: remove the binding label from workloads/pods, delete the `WorkloadPolicy`, then delete the existing `WorkloadPolicyProposal`, or set `security.rancher.io/policy-ready=false` on the proposal to resume learning.
+** *Monitor → Learn*: remove the binding label from workloads/pods, delete the `WorkloadPolicy`, then delete the existing `WorkloadPolicyProposal`, or set `security.rancher.io/promote=false` on the proposal to resume learning.
 
 === CRDs created/updated during this phase
 
@@ -97,7 +97,7 @@ WARNING: The `security.rancher.io/policy` label must be set at Pod creation time
 ** Update the `WorkloadPolicy` to set `.spec.mode: protect`.
 * *Leave*
 ** *Protect → Monitor*: update the `WorkloadPolicy` and set `.spec.mode: monitor` (or `kubectl runtime-enforcer policy monitor <POLICY_NAME>`).
-** *Protect → Learn*: remove the binding label from workloads/pods, delete the `WorkloadPolicy`, then delete the existing `WorkloadPolicyProposal`, or set `security.rancher.io/policy-ready=false` on the proposal to resume learning.
+** *Protect → Learn*: remove the binding label from workloads/pods, delete the `WorkloadPolicy`, then delete the existing `WorkloadPolicyProposal`, or set `security.rancher.io/promote=false` on the proposal to resume learning.
 
 === CRDs created/updated during this phase
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`security.rancher.io/policy-ready` was recently renamed into `security.rancher.io/promote` https://github.com/rancher-sandbox/runtime-enforcer/pull/722. We need to update the docs accordingly.


**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
