### PR TITLE
refactor: remove a custom helper

### DIFF
--- a/internal/grpcexporter/agent_client_pool.go
+++ b/internal/grpcexporter/agent_client_pool.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,21 +33,6 @@ type AgentClientPool struct {
 	logger        *slog.Logger
 }
 
-func convertLabelStringToSelector(labelString string) (map[string]string, error) {
-	agentLabelSelector := make(map[string]string)
-	labels := strings.SplitSeq(labelString, ",")
-	for label := range labels {
-		parts := strings.Split(label, "=")
-		if len(parts) != 2 { //nolint:mnd // label is composed of 2 parts
-			return nil, fmt.Errorf("label should be in the format 'key=value': %s. Invalid selector %s",
-				label,
-				labelString)
-		}
-		agentLabelSelector[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-	}
-	return agentLabelSelector, nil
-}
-
 func getNamespace() (string, error) {
 	const namespaceNamePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	// Get the agent namespace from the system.
@@ -64,7 +49,7 @@ func getNamespace() (string, error) {
 }
 
 func NewAgentClientPool(poolConf AgentClientPoolConfig) (*AgentClientPool, error) {
-	labelSelector, err := convertLabelStringToSelector(poolConf.LabelSelectorString)
+	labelSelector, err := labels.ConvertSelectorToLabelsMap(poolConf.LabelSelectorString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert agent label selector: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Like we do in the network enforcer, we should use `labels.ConvertSelectorToLabelsMap`

**Which issue(s) this PR fixes**

fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
