### PR TITLE
feat: allow users to directly promote a policy into protect mode

### DIFF
--- a/api/v1alpha1/keys.go
+++ b/api/v1alpha1/keys.go
@@ -2,12 +2,8 @@ package v1alpha1
 
 const (
 	// ProposalPromoteLabelKey is set on a WorkloadPolicyProposal when it is promoted to a WorkloadPolicy.
-	// Valid values are policymode strings ("monitor", "protect"). The value "true" is accepted as an
-	// alias for "monitor" for backward compatibility.
+	// Valid values are policymode strings ("monitor", "protect").
 	ProposalPromoteLabelKey = "security.rancher.io/promote"
-
-	// ProposalPromoteLabelTrueAlias is the legacy promote label value, treated as "monitor" mode.
-	ProposalPromoteLabelTrueAlias = "true"
 
 	// PolicyPromotedFromLabelKey is set on a WorkloadPolicy when it is created by
 	// promoting a WorkloadPolicyProposal.

--- a/api/v1alpha1/keys.go
+++ b/api/v1alpha1/keys.go
@@ -2,7 +2,12 @@ package v1alpha1
 
 const (
 	// ProposalPromoteLabelKey is set on a WorkloadPolicyProposal when it is promoted to a WorkloadPolicy.
+	// Valid values are policymode strings ("monitor", "protect"). The value "true" is accepted as an
+	// alias for "monitor" for backward compatibility.
 	ProposalPromoteLabelKey = "security.rancher.io/promote"
+
+	// ProposalPromoteLabelTrueAlias is the legacy promote label value, treated as "monitor" mode.
+	ProposalPromoteLabelTrueAlias = "true"
 
 	// PolicyPromotedFromLabelKey is set on a WorkloadPolicy when it is created by
 	// promoting a WorkloadPolicyProposal.

--- a/api/v1alpha1/workloadpolicyproposal_test.go
+++ b/api/v1alpha1/workloadpolicyproposal_test.go
@@ -4,9 +4,83 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
+	t.Run("nil proposal", func(t *testing.T) {
+		var p *WorkloadPolicyProposal
+		has, mode := p.HasPromotionLabel()
+		require.False(t, has)
+		require.Empty(t, mode)
+		p.SetPromotionLabel(policymode.MonitorString)
+	})
+
+	t.Run("missing label", func(t *testing.T) {
+		p := &WorkloadPolicyProposal{}
+		has, mode := p.HasPromotionLabel()
+		require.False(t, has)
+		require.Empty(t, mode)
+	})
+
+	tests := []struct {
+		name       string
+		labelValue string
+		wantHas    bool
+		wantMode   string
+	}{
+		{
+			name:       "true alias maps to monitor",
+			labelValue: ProposalPromoteLabelTrueAlias,
+			wantHas:    true,
+			wantMode:   policymode.MonitorString,
+		},
+		{
+			name:       "monitor",
+			labelValue: policymode.MonitorString,
+			wantHas:    true,
+			wantMode:   policymode.MonitorString,
+		},
+		{
+			name:       "protect",
+			labelValue: policymode.ProtectString,
+			wantHas:    true,
+			wantMode:   policymode.ProtectString,
+		},
+		{
+			name:       "unsupported value is ignored",
+			labelValue: "invalid",
+			wantHas:    false,
+			wantMode:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						ProposalPromoteLabelKey: tc.labelValue,
+					},
+				},
+			}
+			has, mode := p.HasPromotionLabel()
+			require.Equal(t, tc.wantHas, has)
+			require.Equal(t, tc.wantMode, mode)
+		})
+	}
+
+	t.Run("SetPromotionLabel sets mode", func(t *testing.T) {
+		p := &WorkloadPolicyProposal{}
+		p.SetPromotionLabel(policymode.ProtectString)
+		has, mode := p.HasPromotionLabel()
+		require.True(t, has)
+		require.Equal(t, policymode.ProtectString, p.Labels[ProposalPromoteLabelKey])
+		require.Equal(t, policymode.ProtectString, mode)
+	})
+}
 
 func TestWorkloadPolicyProposalNamespacedName(t *testing.T) {
 	t.Run("nil proposal returns empty string", func(t *testing.T) {

--- a/api/v1alpha1/workloadpolicyproposal_test.go
+++ b/api/v1alpha1/workloadpolicyproposal_test.go
@@ -12,7 +12,7 @@ import (
 func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
 	t.Run("nil proposal", func(t *testing.T) {
 		var p *WorkloadPolicyProposal
-		has, mode := p.HasPromotionLabel()
+		mode, has := p.HasPromotionLabel()
 		require.False(t, has)
 		require.Empty(t, mode)
 		p.SetPromotionLabel(policymode.MonitorString)
@@ -20,7 +20,7 @@ func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
 
 	t.Run("missing label", func(t *testing.T) {
 		p := &WorkloadPolicyProposal{}
-		has, mode := p.HasPromotionLabel()
+		mode, has := p.HasPromotionLabel()
 		require.False(t, has)
 		require.Empty(t, mode)
 	})
@@ -31,12 +31,6 @@ func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
 		wantHas    bool
 		wantMode   string
 	}{
-		{
-			name:       "true alias maps to monitor",
-			labelValue: ProposalPromoteLabelTrueAlias,
-			wantHas:    true,
-			wantMode:   policymode.MonitorString,
-		},
 		{
 			name:       "monitor",
 			labelValue: policymode.MonitorString,
@@ -66,7 +60,7 @@ func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
 					},
 				},
 			}
-			has, mode := p.HasPromotionLabel()
+			mode, has := p.HasPromotionLabel()
 			require.Equal(t, tc.wantHas, has)
 			require.Equal(t, tc.wantMode, mode)
 		})
@@ -75,7 +69,7 @@ func TestWorkloadPolicyProposalPromotionLabel(t *testing.T) {
 	t.Run("SetPromotionLabel sets mode", func(t *testing.T) {
 		p := &WorkloadPolicyProposal{}
 		p.SetPromotionLabel(policymode.ProtectString)
-		has, mode := p.HasPromotionLabel()
+		mode, has := p.HasPromotionLabel()
 		require.True(t, has)
 		require.Equal(t, policymode.ProtectString, p.Labels[ProposalPromoteLabelKey])
 		require.Equal(t, policymode.ProtectString, mode)

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -79,21 +79,21 @@ func (p *WorkloadPolicyProposal) SetPromotionLabel(mode string) {
 
 // HasPromotionLabel reports whether the proposal has a valid promotion label and
 // returns the target WorkloadPolicy mode when it does.
-func (p *WorkloadPolicyProposal) HasPromotionLabel() (bool, string) {
+func (p *WorkloadPolicyProposal) HasPromotionLabel() (string, bool) {
 	if p == nil {
-		return false, ""
+		return "", false
 	}
 	val, ok := p.Labels[ProposalPromoteLabelKey]
 	if !ok {
-		return false, ""
+		return "", false
 	}
 	switch val {
-	case ProposalPromoteLabelTrueAlias, policymode.MonitorString:
-		return true, policymode.MonitorString
+	case policymode.MonitorString:
+		return policymode.MonitorString, true
 	case policymode.ProtectString:
-		return true, policymode.ProtectString
+		return policymode.ProtectString, true
 	default:
-		return false, ""
+		return "", false
 	}
 }
 

--- a/api/v1alpha1/workloadpolicyproposal_types.go
+++ b/api/v1alpha1/workloadpolicyproposal_types.go
@@ -67,21 +67,34 @@ func (p *WorkloadPolicyProposal) NamespacedName() string {
 	return p.Namespace + "/" + p.Name
 }
 
-func (p *WorkloadPolicyProposal) SetPromotionLabel() {
+func (p *WorkloadPolicyProposal) SetPromotionLabel(mode string) {
 	if p == nil {
 		return
 	}
 	if p.Labels == nil {
 		p.SetLabels(map[string]string{})
 	}
-	p.Labels[ProposalPromoteLabelKey] = "true"
+	p.Labels[ProposalPromoteLabelKey] = mode
 }
 
-func (p *WorkloadPolicyProposal) HasPromotionLabel() bool {
+// HasPromotionLabel reports whether the proposal has a valid promotion label and
+// returns the target WorkloadPolicy mode when it does.
+func (p *WorkloadPolicyProposal) HasPromotionLabel() (bool, string) {
 	if p == nil {
-		return false
+		return false, ""
 	}
-	return p.Labels[ProposalPromoteLabelKey] == "true"
+	val, ok := p.Labels[ProposalPromoteLabelKey]
+	if !ok {
+		return false, ""
+	}
+	switch val {
+	case ProposalPromoteLabelTrueAlias, policymode.MonitorString:
+		return true, policymode.MonitorString
+	case policymode.ProtectString:
+		return true, policymode.ProtectString
+	default:
+		return false, ""
+	}
 }
 
 func (p *WorkloadPolicyProposal) IsFull() bool {
@@ -119,10 +132,9 @@ func (p *WorkloadPolicyProposal) AddPartialOwnerReferenceDetails(workloadKind st
 	}
 }
 
-func (p *WorkloadPolicyProposalSpec) IntoWorkloadPolicySpec() WorkloadPolicySpec {
-	// enforcement mode to "monitor" by default.
+func (p *WorkloadPolicyProposalSpec) IntoWorkloadPolicySpec(mode string) WorkloadPolicySpec {
 	return WorkloadPolicySpec{
-		Mode:             policymode.MonitorString,
+		Mode:             mode,
 		RulesByContainer: p.RulesByContainer,
 	}
 }

--- a/charts/runtime-enforcer/templates/controller/webhook.yaml
+++ b/charts/runtime-enforcer/templates/controller/webhook.yaml
@@ -59,3 +59,23 @@ webhooks:
     resources:
     - workloadpolicies
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "runtime-enforcer.fullname" . }}-controller-webhook
+      namespace: {{ .Release.Namespace }}
+      path: /validate-security-rancher-io-v1alpha1-workloadpolicyproposal
+  failurePolicy: Fail
+  name: validate-workloadpolicyproposals.rancher.io
+  rules:
+  - apiGroups:
+    - security.rancher.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloadpolicyproposals
+  sideEffects: None

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -424,8 +424,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	proposalWebhook := &controller.ProposalWebhook{Client: mgr.GetClient()}
 	err = builder.WebhookManagedBy(mgr, &securityv1alpha1.WorkloadPolicyProposal{}).
-		WithDefaulter(&controller.ProposalWebhook{Client: mgr.GetClient()}).
+		WithDefaulter(proposalWebhook).
+		WithValidator(proposalWebhook).
 		Complete()
 	if err != nil {
 		setupLog.Error(err, "unable to create WorkloadPolicyProposal webhook")

--- a/docs/kubectl-plugin/runtime-enforcer_proposal_promote.md
+++ b/docs/kubectl-plugin/runtime-enforcer_proposal_promote.md
@@ -13,8 +13,9 @@ runtime-enforcer proposal promote PROPOSAL_NAME [flags]
 ### Options
 
 ```
-      --dry-run   Show what would happen without making any changes
-  -h, --help      help for promote
+      --dry-run       Show what would happen without making any changes
+  -h, --help          help for promote
+      --mode string   Policy mode for the promoted WorkloadPolicy (monitor or protect) (default "monitor")
 ```
 
 ### Options inherited from parent commands

--- a/internal/controller/workloadpolicyproposal_controller.go
+++ b/internal/controller/workloadpolicyproposal_controller.go
@@ -63,7 +63,7 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
-	hasPromotionLabel, mode := proposal.HasPromotionLabel()
+	mode, hasPromotionLabel := proposal.HasPromotionLabel()
 	if !hasPromotionLabel {
 		return ctrl.Result{}, nil
 	}

--- a/internal/controller/workloadpolicyproposal_controller.go
+++ b/internal/controller/workloadpolicyproposal_controller.go
@@ -63,7 +63,8 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 		return ctrl.Result{}, nil
 	}
 
-	if !proposal.HasPromotionLabel() {
+	hasPromotionLabel, mode := proposal.HasPromotionLabel()
+	if !hasPromotionLabel {
 		return ctrl.Result{}, nil
 	}
 
@@ -72,7 +73,7 @@ func (r *WorkloadPolicyProposalReconciler) Reconcile(
 			Name:      proposal.Name,
 			Namespace: proposal.Namespace,
 		},
-		Spec: proposal.Spec.IntoWorkloadPolicySpec(),
+		Spec: proposal.Spec.IntoWorkloadPolicySpec(mode),
 	}
 	if err = policy.SetPromotedLabel(proposal.Name); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set promoted label: %w", err)

--- a/internal/controller/workloadpolicyproposals_webhook.go
+++ b/internal/controller/workloadpolicyproposals_webhook.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -13,13 +14,19 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+// +kubebuilder:webhook:path=/validate-security-rancher-io-v1alpha1-workloadpolicyproposal,mutating=false,failurePolicy=fail,sideEffects=None,groups=security.rancher.io,resources=workloadpolicyproposals,verbs=create;update,versions=v1alpha1,name=validate-workloadpolicyproposals.rancher.io,admissionReviewVersions=v1
 
 type ProposalWebhook struct {
 	Client client.Client
 }
+
+var _ admission.Validator[*securityv1alpha1.WorkloadPolicyProposal] = &ProposalWebhook{}
 
 var _ apierrors.APIStatus = (*ProposalValidatorError)(nil)
 
@@ -180,4 +187,55 @@ func (p *ProposalWebhook) Default(ctx context.Context, proposal *securityv1alpha
 	}
 
 	return p.updateResource(ctx, proposal)
+}
+
+func (p *ProposalWebhook) ValidateCreate(
+	ctx context.Context,
+	proposal *securityv1alpha1.WorkloadPolicyProposal,
+) (admission.Warnings, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Validation for WorkloadPolicyProposal upon creation", "name", proposal.GetName())
+	return nil, p.validatePromotionLabel(proposal)
+}
+
+func (p *ProposalWebhook) ValidateUpdate(
+	ctx context.Context,
+	_, newProposal *securityv1alpha1.WorkloadPolicyProposal,
+) (admission.Warnings, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("Validation for WorkloadPolicyProposal upon update", "name", newProposal.GetName())
+	return nil, p.validatePromotionLabel(newProposal)
+}
+
+func (p *ProposalWebhook) ValidateDelete(
+	_ context.Context,
+	_ *securityv1alpha1.WorkloadPolicyProposal,
+) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (p *ProposalWebhook) validatePromotionLabel(proposal *securityv1alpha1.WorkloadPolicyProposal) error {
+	val, ok := proposal.Labels[securityv1alpha1.ProposalPromoteLabelKey]
+	if !ok {
+		return nil
+	}
+	if _, valid := proposal.HasPromotionLabel(); valid {
+		return nil
+	}
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: "security.rancher.io", Kind: "WorkloadPolicyProposal"},
+		proposal.Name,
+		field.ErrorList{
+			field.Invalid(
+				field.NewPath("metadata", "labels").Key(securityv1alpha1.ProposalPromoteLabelKey),
+				val,
+				fmt.Sprintf(
+					"unsupported value %q: must be %q or %q",
+					val,
+					policymode.MonitorString,
+					policymode.ProtectString,
+				),
+			),
+		},
+	)
 }

--- a/internal/controller/workloadpolicyproposals_webhook_test.go
+++ b/internal/controller/workloadpolicyproposals_webhook_test.go
@@ -6,8 +6,10 @@ import (
 
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/controller"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -133,6 +135,67 @@ var _ = Describe("WorkloadPolicyProposal Webhook", func() {
 					Expect(err).To(HaveOccurred())
 				}
 			}
+		})
+	})
+
+	Context("ValidatePromotionLabel", func() {
+		var webhook *controller.ProposalWebhook
+
+		BeforeEach(func() {
+			webhook = &controller.ProposalWebhook{}
+		})
+
+		It("allows create without promote label", func() {
+			proposal := &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-proposal"},
+			}
+			warns, err := webhook.ValidateCreate(ctx, proposal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warns).To(BeEmpty())
+		})
+
+		It("allows create with monitor promote label", func() {
+			proposal := &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-proposal",
+					Labels: map[string]string{
+						securityv1alpha1.ProposalPromoteLabelKey: policymode.MonitorString,
+					},
+				},
+			}
+			warns, err := webhook.ValidateCreate(ctx, proposal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warns).To(BeEmpty())
+		})
+
+		It("allows update with protect promote label", func() {
+			proposal := &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-proposal",
+					Labels: map[string]string{
+						securityv1alpha1.ProposalPromoteLabelKey: policymode.ProtectString,
+					},
+				},
+			}
+			warns, err := webhook.ValidateUpdate(ctx, proposal, proposal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warns).To(BeEmpty())
+		})
+
+		It("denies create with unsupported promote label", func() {
+			proposal := &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-proposal",
+					Labels: map[string]string{
+						securityv1alpha1.ProposalPromoteLabelKey: "true",
+					},
+				},
+			}
+			warns, err := webhook.ValidateCreate(ctx, proposal)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring(`unsupported value "true"`))
+			Expect(warns).To(BeEmpty())
 		})
 	})
 })

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -282,7 +282,7 @@ func (r *LearningReconciler) reconcile(
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {
 		// We don't learn any new process if the policy proposal was promoted
 		// to an actual policy
-		if hasPromotionLabel, _ := policyProposal.HasPromotionLabel(); hasPromotionLabel {
+		if _, hasPromotionLabel := policyProposal.HasPromotionLabel(); hasPromotionLabel {
 			return nil
 		}
 

--- a/internal/eventhandler/learning_controller.go
+++ b/internal/eventhandler/learning_controller.go
@@ -282,7 +282,7 @@ func (r *LearningReconciler) reconcile(
 	if _, err = controllerutil.CreateOrUpdate(ctx, r.Client, policyProposal, func() error {
 		// We don't learn any new process if the policy proposal was promoted
 		// to an actual policy
-		if policyProposal.HasPromotionLabel() {
+		if hasPromotionLabel, _ := policyProposal.HasPromotionLabel(); hasPromotionLabel {
 			return nil
 		}
 

--- a/internal/eventhandler/learning_controller_test.go
+++ b/internal/eventhandler/learning_controller_test.go
@@ -7,6 +7,7 @@ import (
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventhandler"
 	"github.com/rancher-sandbox/runtime-enforcer/internal/eventscraper"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	"golang.org/x/sync/errgroup"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -332,7 +333,7 @@ var _ = Describe("Learning", func() {
 			testProposal := proposal.DeepCopy()
 			testProposal.Namespace = testNamespace
 			testProposal.Name = testProposalName
-			testProposal.SetPromotionLabel()
+			testProposal.SetPromotionLabel(policymode.MonitorString)
 			Expect(k8sClient.Create(ctx, testProposal)).To(Succeed())
 
 			for _, learningEvent := range processEvents {

--- a/internal/kubectlplugin/proposal_promote.go
+++ b/internal/kubectlplugin/proposal_promote.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	securityclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/typed/api/v1alpha1"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +19,7 @@ type proposalPromoteOptions struct {
 	commonOptions
 
 	ProposalName string
+	Mode         string
 }
 
 func newProposalPromoteCmdValidArgsFunction(
@@ -40,6 +42,7 @@ func newProposalPromoteCmdValidArgsFunction(
 func newProposalPromoteCmd(deps commonCmdDeps) *cobra.Command {
 	opts := &proposalPromoteOptions{
 		commonOptions: newCommonOptions(deps),
+		Mode:          policymode.MonitorString,
 	}
 
 	cmd := &cobra.Command{
@@ -55,6 +58,12 @@ func newProposalPromoteCmd(deps commonCmdDeps) *cobra.Command {
 
 	// Plugin-specific flags
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would happen without making any changes")
+	cmd.Flags().StringVar(
+		&opts.Mode,
+		"mode",
+		policymode.MonitorString,
+		fmt.Sprintf("Policy mode for the promoted WorkloadPolicy (%s or %s)", policymode.MonitorString, policymode.ProtectString),
+	)
 
 	return cmd
 }
@@ -78,6 +87,15 @@ func runProposalPromote(
 	opts *proposalPromoteOptions,
 	out io.Writer,
 ) error {
+	if !policymode.IsValid(opts.Mode) {
+		return fmt.Errorf(
+			"invalid mode %q: must be %q or %q",
+			opts.Mode,
+			policymode.MonitorString,
+			policymode.ProtectString,
+		)
+	}
+
 	proposal, err := client.WorkloadPolicyProposals(opts.Namespace).Get(ctx, opts.ProposalName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -91,7 +109,7 @@ func runProposalPromote(
 		)
 	}
 
-	if proposal.HasPromotionLabel() {
+	if hasPromotionLabel, _ := proposal.HasPromotionLabel(); hasPromotionLabel {
 		fmt.Fprintf(
 			out,
 			"WorkloadPolicyProposal %q in namespace %q is already promoted to WorkloadPolicy.\n",
@@ -106,7 +124,7 @@ func runProposalPromote(
 		updateOptions.DryRun = []string{metav1.DryRunAll}
 	}
 
-	proposal.SetPromotionLabel()
+	proposal.SetPromotionLabel(opts.Mode)
 
 	if _, err = client.WorkloadPolicyProposals(opts.Namespace).
 		Update(ctx, proposal, updateOptions); err != nil {

--- a/internal/kubectlplugin/proposal_promote.go
+++ b/internal/kubectlplugin/proposal_promote.go
@@ -109,7 +109,7 @@ func runProposalPromote(
 		)
 	}
 
-	if hasPromotionLabel, _ := proposal.HasPromotionLabel(); hasPromotionLabel {
+	if _, hasPromotionLabel := proposal.HasPromotionLabel(); hasPromotionLabel {
 		fmt.Fprintf(
 			out,
 			"WorkloadPolicyProposal %q in namespace %q is already promoted to WorkloadPolicy.\n",

--- a/internal/kubectlplugin/proposal_promote_test.go
+++ b/internal/kubectlplugin/proposal_promote_test.go
@@ -130,7 +130,7 @@ func TestRunProposalPromote(t *testing.T) {
 					Name:      name,
 					Namespace: ns,
 					Labels: map[string]string{
-						securityv1alpha1.ProposalPromoteLabelKey: "true",
+						securityv1alpha1.ProposalPromoteLabelKey: policymode.MonitorString,
 					},
 				},
 			},
@@ -139,7 +139,7 @@ func TestRunProposalPromote(t *testing.T) {
 				name,
 				ns,
 			),
-			expectLabel: "true",
+			expectLabel: policymode.MonitorString,
 		},
 		{
 			name: "rejects invalid mode",
@@ -201,7 +201,7 @@ func TestRunProposalPromote(t *testing.T) {
 			// The fake client ignores DryRun and still mutates the object, so we
 			// still assert the updated label even in dry-run mode.
 			if !tt.skipLabelCheck {
-				hasPromotionLabel, _ := wpProposal.HasPromotionLabel()
+				_, hasPromotionLabel := wpProposal.HasPromotionLabel()
 				require.True(t, hasPromotionLabel)
 				require.Equal(t, tt.expectLabel, wpProposal.Labels[securityv1alpha1.ProposalPromoteLabelKey])
 			}

--- a/internal/kubectlplugin/proposal_promote_test.go
+++ b/internal/kubectlplugin/proposal_promote_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	securityv1alpha1 "github.com/rancher-sandbox/runtime-enforcer/api/v1alpha1"
+	"github.com/rancher-sandbox/runtime-enforcer/internal/types/policymode"
 	fakeclient "github.com/rancher-sandbox/runtime-enforcer/pkg/generated/clientset/versioned/fake"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -24,14 +25,20 @@ func TestRunProposalPromote(t *testing.T) {
 	)
 
 	tests := []struct {
-		name         string
-		dryRun       bool
-		proposal     *securityv1alpha1.WorkloadPolicyProposal
-		policy       *securityv1alpha1.WorkloadPolicy
-		expectOutput string
+		name           string
+		dryRun         bool
+		mode           string
+		omitMode       bool
+		proposal       *securityv1alpha1.WorkloadPolicyProposal
+		policy         *securityv1alpha1.WorkloadPolicy
+		expectOutput   string
+		expectErr      string
+		expectLabel    string
+		skipLabelCheck bool
 	}{
 		{
 			name: "promotes proposal and waits for policy",
+			mode: policymode.MonitorString,
 			proposal: &securityv1alpha1.WorkloadPolicyProposal{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -49,10 +56,56 @@ func TestRunProposalPromote(t *testing.T) {
 				name,
 				ns,
 			),
+			expectLabel: policymode.MonitorString,
+		},
+		{
+			name: "promotes proposal in protect mode",
+			mode: policymode.ProtectString,
+			proposal: &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+			policy: &securityv1alpha1.WorkloadPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+			expectOutput: fmt.Sprintf(
+				"Promoted WorkloadPolicyProposal %q in namespace %q to WorkloadPolicy.",
+				name,
+				ns,
+			),
+			expectLabel: policymode.ProtectString,
+		},
+		{
+			name:     "defaults to monitor when mode is omitted",
+			omitMode: true,
+			proposal: &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+			policy: &securityv1alpha1.WorkloadPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+			expectOutput: fmt.Sprintf(
+				"Promoted WorkloadPolicyProposal %q in namespace %q to WorkloadPolicy.",
+				name,
+				ns,
+			),
+			expectLabel: policymode.MonitorString,
 		},
 		{
 			name:   "dry-run when not yet promoted",
 			dryRun: true,
+			mode:   policymode.MonitorString,
 			proposal: &securityv1alpha1.WorkloadPolicyProposal{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -66,10 +119,12 @@ func TestRunProposalPromote(t *testing.T) {
 				name,
 				ns,
 			),
+			expectLabel: policymode.MonitorString,
 		},
 		{
 			name:   "dry-run when already promoted",
 			dryRun: true,
+			mode:   policymode.MonitorString,
 			proposal: &securityv1alpha1.WorkloadPolicyProposal{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
@@ -84,12 +139,39 @@ func TestRunProposalPromote(t *testing.T) {
 				name,
 				ns,
 			),
+			expectLabel: "true",
+		},
+		{
+			name: "rejects invalid mode",
+			mode: "invalid",
+			proposal: &securityv1alpha1.WorkloadPolicyProposal{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: ns,
+				},
+			},
+			expectErr:      `invalid mode "invalid"`,
+			skipLabelCheck: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			mode := tt.mode
+			if tt.omitMode {
+				tf, streams := setupTestFactory(t, tt.proposal.DeepCopy())
+				defer tf.Cleanup()
+
+				cmd := newProposalPromoteCmd(commonCmdDeps{f: tf, ioStreams: streams})
+				// kubectl runtime-enforcer proposal promote PROPOSAL_NAME (no --mode)
+				require.NoError(t, cmd.ParseFlags([]string{}))
+				var err error
+				mode, err = cmd.Flags().GetString("mode")
+				require.NoError(t, err)
+				require.Equal(t, policymode.MonitorString, mode)
+			}
 
 			securityClient := newProposalPromoteTestClient(tt.proposal, tt.policy).SecurityV1alpha1()
 
@@ -100,11 +182,17 @@ func TestRunProposalPromote(t *testing.T) {
 					DryRun:    tt.dryRun,
 				},
 				ProposalName: name,
+				Mode:         mode,
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
 			defer cancel()
 
 			err := runProposalPromote(ctx, securityClient, opts, &out)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
 			require.NoError(t, err)
 
 			wpProposal, err := securityClient.WorkloadPolicyProposals(ns).Get(ctx, name, metav1.GetOptions{})
@@ -112,7 +200,11 @@ func TestRunProposalPromote(t *testing.T) {
 
 			// The fake client ignores DryRun and still mutates the object, so we
 			// still assert the updated label even in dry-run mode.
-			require.True(t, wpProposal.HasPromotionLabel())
+			if !tt.skipLabelCheck {
+				hasPromotionLabel, _ := wpProposal.HasPromotionLabel()
+				require.True(t, hasPromotionLabel)
+				require.Equal(t, tt.expectLabel, wpProposal.Labels[securityv1alpha1.ProposalPromoteLabelKey])
+			}
 			require.Contains(t, out.String(), tt.expectOutput)
 		})
 	}
@@ -146,4 +238,8 @@ func TestCompleteProposalPromoteArgs(t *testing.T) {
 	completes, directive := cmd.ValidArgsFunction(cmd, []string{}, "")
 	assert.Equal(t, []string{proposalName}, completes)
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+
+	modeFlag := cmd.Flags().Lookup("mode")
+	require.NotNil(t, modeFlag)
+	assert.Equal(t, policymode.MonitorString, modeFlag.DefValue)
 }

--- a/internal/types/policymode/policy_mode.go
+++ b/internal/types/policymode/policy_mode.go
@@ -35,6 +35,15 @@ func FromUint8(v uint8) Mode {
 	}
 }
 
+func IsValid(mode string) bool {
+	switch mode {
+	case MonitorString, ProtectString:
+		return true
+	default:
+		return false
+	}
+}
+
 func ParseMode(s string) Mode {
 	switch s {
 	case MonitorString:

--- a/test/e2e/promotion_test.go
+++ b/test/e2e/promotion_test.go
@@ -99,7 +99,7 @@ func getPromotionTest() types.Feature {
 
 				t.Log("promote the policy proposal: ", proposal.Name)
 
-				proposal.SetPromotionLabel()
+				proposal.SetPromotionLabel(policymode.MonitorString)
 				err := r.Update(ctx, proposal)
 				require.NoError(t, err)
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

enhancement
bug
documentation
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->
Allow users to directly promote a policy into both monitor or protect mode

**Which issue(s) this PR fixes**

fixes #781 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
