### PR TITLE
fix(metrics): separate violation and acknowledge counters

### DIFF
--- a/charts/runtime-enforcer/templates/otel-collector/configmap.yaml
+++ b/charts/runtime-enforcer/templates/otel-collector/configmap.yaml
@@ -20,6 +20,8 @@ data:
         logs:
           runtime_enforcer_violations:
             description: "Total policy violations detected by runtime-enforcer"
+            conditions:
+              - 'body == "policy_violation"'
             attributes:
               - key: policy.name
               - key: k8s.namespace.name
@@ -27,6 +29,8 @@ data:
               - key: node.name
           runtime_enforcer_acknowledge:
             description: "Total acknowledged violations by runtime-enforcer"
+            conditions:
+              - 'body == "policy_violation_acknowledged"'
             attributes:
               - key: policy.name
               - key: k8s.namespace.name

--- a/internal/controller/workloadpolicystatus_helpers.go
+++ b/internal/controller/workloadpolicystatus_helpers.go
@@ -50,7 +50,7 @@ func (r *WorkloadPolicyStatusSync) processWorkloadPolicy(
 	// Only if the status update was successful we emit the logs.
 	// In this way we won't send duplicate logs in case of retries
 	for _, ack := range acknowledged {
-		r.emitAcknowledgedViolationOtelLog(ctx, ack)
+		r.emitAcknowledgedViolationOtelLog(ctx, newPolicy.Name, newPolicy.Namespace, ack)
 	}
 
 	err = r.Patch(ctx, newPolicy.DeepCopy(), patchBase)

--- a/internal/controller/workloadpolicystatus_sync.go
+++ b/internal/controller/workloadpolicystatus_sync.go
@@ -176,6 +176,7 @@ func (r *WorkloadPolicyStatusSync) getViolationsByPolicy(
 
 func (r *WorkloadPolicyStatusSync) emitAcknowledgedViolationOtelLog(
 	ctx context.Context,
+	policyName, namespace string,
 	ack v1alpha1.AcknowledgedViolationRecord,
 ) {
 	if r.eventLogger == nil {
@@ -192,6 +193,8 @@ func (r *WorkloadPolicyStatusSync) emitAcknowledgedViolationOtelLog(
 		otellog.Int64("id", violation.ID),
 		otellog.String("timestamp", violation.Timestamp.UTC().Format(time.RFC3339)),
 		otellog.String("reason", ack.Reason),
+		otellog.String("policy.name", policyName),
+		otellog.String("k8s.namespace.name", namespace),
 		otellog.String("k8s.pod.name", violation.PodName),
 		otellog.String("container.name", violation.ContainerName),
 		otellog.String("proc.exepath", violation.ExecutablePath),

--- a/test/e2e/monitoring_test.go
+++ b/test/e2e/monitoring_test.go
@@ -241,6 +241,11 @@ func assessAcknowledgeMetric(ctx context.Context, t *testing.T, config *envconf.
 	assertMetricHasLabel(t, metricsBody, "runtime_enforcer_acknowledge", "action", policymode.MonitorString)
 	assertMetricHasLabelKey(t, metricsBody, "runtime_enforcer_acknowledge", "node_name")
 
+	// We acknowledged one violation once, so the counter must be exactly 1.
+	// If the count connector also counted policy_violation logs it would be
+	// higher, which is what keeps the two metrics apart.
+	assertMetricValue(t, metricsBody, "runtime_enforcer_acknowledge", "policy_name", "test-policy", 1)
+
 	return ctx
 }
 

--- a/test/e2e/otel_test.go
+++ b/test/e2e/otel_test.go
@@ -362,6 +362,42 @@ func assertMetricHasLabelKey(t *testing.T, body, metricName, labelKey string) {
 		"expected metric %q to have label key %q", metricName, labelKey)
 }
 
+// metricValue returns the value of the first sample line for the given metric
+// carrying the label key=value pair, or false if there is none.
+func metricValue(body, metricName, labelKey, labelValue string) (float64, bool) {
+	expected := fmt.Sprintf(`%s="%s"`, labelKey, labelValue)
+	for line := range strings.SplitSeq(body, "\n") {
+		if !strings.HasPrefix(line, metricName) || !strings.Contains(line, expected) {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		return v, true
+	}
+	return 0, false
+}
+
+// assertMetricValue checks that the sample selected by the label key=value pair
+// equals the expected value.
+func assertMetricValue(t *testing.T, body, metricName, labelKey, labelValue string, expected float64) {
+	t.Helper()
+
+	v, ok := metricValue(body, metricName, labelKey, labelValue)
+	if !ok {
+		assert.Failf(t, "metric sample not found",
+			"expected metric %q with label %s=%q to be present", metricName, labelKey, labelValue)
+		return
+	}
+	assert.InDeltaf(t, expected, v, 0.0001,
+		"metric %q with label %s=%q should equal %v", metricName, labelKey, labelValue, expected)
+}
+
 // assertMetricHasNoLabelKey checks that no sample line for the given metric
 // carries the given label key.
 func assertMetricHasNoLabelKey(t *testing.T, body, metricName, labelKey string) {

--- a/test/e2e/otel_test.go
+++ b/test/e2e/otel_test.go
@@ -363,7 +363,14 @@ func assertMetricHasLabelKey(t *testing.T, body, metricName, labelKey string) {
 }
 
 // metricValue returns the value of the first sample line for the given metric
-// carrying the label key=value pair, or false if there is none.
+// carrying the label key=value pair, or false if there is none. The lines it
+// parses are Prometheus exposition format, e.g.
+//
+//	runtime_enforcer_acknowledge_total{policy_name="test-policy",action="monitor"} 1
+//	runtime_enforcer_violations_total{policy_name="test-policy",action="monitor"} 4.2e+07
+//
+// Sample values are always float-typed there (large counters use scientific
+// notation), so we parse them as float64.
 func metricValue(body, metricName, labelKey, labelValue string) (float64, bool) {
 	expected := fmt.Sprintf(`%s="%s"`, labelKey, labelValue)
 	for line := range strings.SplitSeq(body, "\n") {
@@ -389,11 +396,9 @@ func assertMetricValue(t *testing.T, body, metricName, labelKey, labelValue stri
 	t.Helper()
 
 	v, ok := metricValue(body, metricName, labelKey, labelValue)
-	if !ok {
-		assert.Failf(t, "metric sample not found",
-			"expected metric %q with label %s=%q to be present", metricName, labelKey, labelValue)
-		return
-	}
+	require.Truef(t, ok,
+		"expected metric %q with label %s=%q to be present, body:\n%s",
+		metricName, labelKey, labelValue, body)
 	assert.InDeltaf(t, expected, v, 0.0001,
 		"metric %q with label %s=%q should equal %v", metricName, labelKey, labelValue, expected)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The count connector had no conditions, so every emitted log incremented both `runtime_enforcer_violations` and `runtime_enforcer_acknowledge`. Add a body-based condition to each metric so violation and acknowledge logs feed only their own counter, and add the missing `policy.name` / `k8s.namespace.name` attributes to the acknowledge event. E2E asserts the acknowledge counter equals 1 to lock in the split.
